### PR TITLE
Feature/cache tag centralization

### DIFF
--- a/app/(main)/_component/ReleasedBundleList.tsx
+++ b/app/(main)/_component/ReleasedBundleList.tsx
@@ -1,5 +1,5 @@
 import { BundleCarousel } from '@/components/bundle/BundleCarousel';
-import { getReleasedBundlesServerAction } from '@/modules/bundle/application/getReleasedBundlesServerAction';
+import { getReleasedBundlesServerAction } from '@/modules/bundle/domain/usecases/getReleasedBundlesServerAction';
 import { BundleType } from '@/modules/bundle/domain/bundle';
 
 interface Props {

--- a/modules/bundle/domain/bundle.repository.ts
+++ b/modules/bundle/domain/bundle.repository.ts
@@ -27,7 +27,7 @@ export interface BundleRepository {
   ) => Promise<DomainBundle[]>;
   create: (data: RepositoryCreateBundleInput) => Promise<DomainBundle>;
   edit: (id: number, data: RepositoryEditBundleInput) => Promise<DomainBundle>;
-  delete: (id: number) => Promise<void>;
+  delete: (id: number) => Promise<DomainBundle>;
 
   likeBundle: (
     userId: string,

--- a/modules/bundle/domain/usecases/createBundleServerAction.ts
+++ b/modules/bundle/domain/usecases/createBundleServerAction.ts
@@ -8,6 +8,7 @@ import {
   UsecaseCreateBundleInputSchema,
 } from '../validations/CreateBundleTypes';
 import { BundleRepository } from '../bundle.repository';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const createBundleServerAction = adminGuard(
   async (
@@ -19,7 +20,7 @@ export const createBundleServerAction = adminGuard(
 
     try {
       const bundle = await repo.create(parsedData);
-      revalidateTag('allBundles');
+      revalidateTag(cacheKeys.ADMIN_ALL_BUNDLES);
 
       return { success: true, bundle };
     } catch (e) {

--- a/modules/bundle/domain/usecases/createBundleTypeServerAction.ts
+++ b/modules/bundle/domain/usecases/createBundleTypeServerAction.ts
@@ -8,6 +8,7 @@ import {
   UsecaseCreateBundleTypeInputSchema,
 } from '../validations/CreateBundleTypeTypes';
 import { revalidateTag } from 'next/cache';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const createBundleTypeServerAction = adminGuard(
   async (
@@ -19,7 +20,7 @@ export const createBundleTypeServerAction = adminGuard(
 
     try {
       const bundleType = await repo.create({ name });
-      revalidateTag('allBundleTypes');
+      revalidateTag(cacheKeys.ALL_BUNDLE_TYPE);
 
       return { success: true, bundleType };
     } catch (e) {

--- a/modules/bundle/domain/usecases/deleteBundleServerAction.ts
+++ b/modules/bundle/domain/usecases/deleteBundleServerAction.ts
@@ -4,14 +4,21 @@ import { repository } from '@/modules/config/repository';
 import { adminGuard } from '@/lib/guard/adminGuard';
 import { revalidateTag } from 'next/cache';
 import { BundleRepository } from '../bundle.repository';
+import { cacheKeys } from '@/modules/config/cacheHelper';
+import { BundleStatus } from '../bundle';
 
 export const deleteBundleServerAction = adminGuard(
   async (id: number, subBundleRepository: BundleRepository | null = null) => {
     const repo = subBundleRepository || repository.bundle;
 
     try {
-      await repo.delete(id);
-      revalidateTag('allBundles');
+      const exist = await repo.delete(id);
+
+      revalidateTag(cacheKeys.ADMIN_ALL_BUNDLES);
+
+      if (exist.status === BundleStatus.PUBLISH) {
+        revalidateTag(cacheKeys.RELEASED_BUNDLES);
+      }
 
       return { success: true };
     } catch (e) {

--- a/modules/bundle/domain/usecases/deleteBundleTypeServerAction.ts
+++ b/modules/bundle/domain/usecases/deleteBundleTypeServerAction.ts
@@ -4,6 +4,7 @@ import { repository } from '@/modules/config/repository';
 import { adminGuard } from '@/lib/guard/adminGuard';
 import { revalidateTag } from 'next/cache';
 import { BundleTypeRepository } from '../bundle.repository';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const deleteBundleTypeServerAction = adminGuard(
   async (
@@ -14,7 +15,9 @@ export const deleteBundleTypeServerAction = adminGuard(
 
     try {
       await repo.delete(id);
-      revalidateTag('allBundleTypes');
+      revalidateTag(cacheKeys.ALL_BUNDLE_TYPE);
+      revalidateTag(cacheKeys.ADMIN_ALL_BUNDLES);
+      revalidateTag(cacheKeys.RELEASED_TRACKS);
 
       return { success: true };
     } catch (e) {

--- a/modules/bundle/domain/usecases/editBundleTypeServerAction.ts
+++ b/modules/bundle/domain/usecases/editBundleTypeServerAction.ts
@@ -8,6 +8,7 @@ import {
   UsecaseEditBundleTypeInputSchema,
 } from '../validations/EditBundleTypeTypes';
 import { BundleTypeRepository } from '../bundle.repository';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const editBundleTypeServerAction = adminGuard(
   async (
@@ -34,7 +35,9 @@ export const editBundleTypeServerAction = adminGuard(
 
     try {
       const result = await repo.edit(id, { name });
-      revalidateTag('allBundleTypes');
+      revalidateTag(cacheKeys.ALL_BUNDLE_TYPE);
+      revalidateTag(cacheKeys.ADMIN_ALL_BUNDLES);
+      revalidateTag(cacheKeys.RELEASED_BUNDLES);
 
       return { success: true, mood: result };
     } catch (e) {

--- a/modules/bundle/domain/usecases/getAllBundleServerAction.ts
+++ b/modules/bundle/domain/usecases/getAllBundleServerAction.ts
@@ -3,6 +3,7 @@
 import { unstable_cache } from 'next/cache';
 import { repository } from '@/modules/config/repository';
 import { BundleRepository } from '../bundle.repository';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const getAllBundlesServerAction = async (
   subBundleRepository: BundleRepository | null = null
@@ -13,11 +14,11 @@ export const getAllBundlesServerAction = async (
     const bundles = unstable_cache(
       async () => {
         const data = await repo.getAll();
-        console.log(`Prisma 호출 : allBundles`);
+        console.log(`Prisma 호출 : ${cacheKeys.ADMIN_ALL_BUNDLES}`);
         return data;
       },
-      [`allBundles`],
-      { tags: [`allBundles`], revalidate: 3600 }
+      [cacheKeys.ADMIN_ALL_BUNDLES],
+      { tags: [cacheKeys.ADMIN_ALL_BUNDLES], revalidate: 3600 }
     )();
     return bundles;
   } catch (e) {

--- a/modules/bundle/domain/usecases/getAllBundleTypesServerAction.ts
+++ b/modules/bundle/domain/usecases/getAllBundleTypesServerAction.ts
@@ -3,6 +3,7 @@
 import { unstable_cache } from 'next/cache';
 import { repository } from '@/modules/config/repository';
 import { BundleTypeRepository } from '../bundle.repository';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const getAllBundleTypesServerAction = async (
   subBundleTypeRepository: BundleTypeRepository | null = null
@@ -13,11 +14,11 @@ export const getAllBundleTypesServerAction = async (
     const bundleTypes = unstable_cache(
       async () => {
         const data = await repo.getAll();
-        console.log(`Prisma 호출 : allBundleTypes`);
+        console.log(`Prisma 호출: ${cacheKeys.ALL_BUNDLE_TYPE}`);
         return data;
       },
-      [`allBundleTypes`],
-      { tags: [`allBundleTypes`], revalidate: 3600 }
+      [cacheKeys.ALL_BUNDLE_TYPE],
+      { tags: [cacheKeys.ALL_BUNDLE_TYPE], revalidate: 3600 }
     )();
     return bundleTypes;
   } catch (e) {

--- a/modules/bundle/domain/usecases/getBundleServerAction.ts
+++ b/modules/bundle/domain/usecases/getBundleServerAction.ts
@@ -3,6 +3,7 @@
 import { repository } from '@/modules/config/repository';
 import { unstable_cache } from 'next/cache';
 import { BundleRepository } from '../bundle.repository';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 // 페이지 네이션 필요
 export const getBundleServerAction = async (
@@ -15,11 +16,14 @@ export const getBundleServerAction = async (
     const track = unstable_cache(
       async () => {
         const data = await repo.findOne(id);
-        console.log(`Prisma 호출 : bundle-${id}`);
+        console.log(`Prisma 호출: ${cacheKeys.getBundle(id)}`);
         return data;
       },
-      [`bundle-${id}`, 'allBundles'],
-      { tags: [`bundle-${id}`, 'allBundles'], revalidate: 3600 }
+      [cacheKeys.getBundle(id)],
+      {
+        tags: [cacheKeys.getBundle(id)],
+        revalidate: 3600,
+      }
     )();
     return track;
   } catch (e) {

--- a/modules/bundle/domain/usecases/getLikedBundlesServerAction.ts
+++ b/modules/bundle/domain/usecases/getLikedBundlesServerAction.ts
@@ -3,6 +3,7 @@
 import { repository } from '@/modules/config/repository';
 import { unstable_cache } from 'next/cache';
 import { BundleRepository } from '../bundle.repository';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 // 페이지 네이션 필요
 export const getLikedBundlesServerAction = async (
@@ -17,12 +18,12 @@ export const getLikedBundlesServerAction = async (
     const likedBundles = await unstable_cache(
       async () => {
         const data = await repo.getLikedBundlesByUser(userId);
-        console.log(`Prisma 호출 : likedBundles-${userId}`);
+        console.log(`Prisma 호출: ${cacheKeys.getLikedBundlesByUser(userId)}`);
         return data;
       },
-      [`likedBundles-${userId}`],
+      [cacheKeys.getLikedBundlesByUser(userId)],
       {
-        tags: [`likedBundles-${userId}`],
+        tags: [cacheKeys.getLikedBundlesByUser(userId)],
         revalidate: 3600,
       }
     )();

--- a/modules/bundle/domain/usecases/getReleasedBundlesServerAction.ts
+++ b/modules/bundle/domain/usecases/getReleasedBundlesServerAction.ts
@@ -2,8 +2,9 @@
 
 import { repository } from '@/modules/config/repository';
 import { unstable_cache } from 'next/cache';
-import { RepositoryGetBundlesQuery } from '../domain/validations/GetBundlesTypes';
-import { BundleRepository } from '../domain/bundle.repository';
+import { RepositoryGetBundlesQuery } from '../validations/GetBundlesTypes';
+import { BundleRepository } from '../bundle.repository';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const getReleasedBundlesServerAction = async (
   query: Pick<RepositoryGetBundlesQuery, 'type'>,
@@ -20,15 +21,18 @@ export const getReleasedBundlesServerAction = async (
           count: 12,
         });
 
-        console.log(`Prisma 호출 : releasedBundles-${query.type}`);
+        console.log(
+          `Prisma 호출: ${cacheKeys.getReleasedBundlesByType(
+            query.type ?? 'all'
+          )}`
+        );
         return data;
       },
-      [`releasedBundles-${query.type}`, 'releasedBundles', 'allBundles'],
+      [cacheKeys.getReleasedBundlesByType(query.type ?? 'all')],
       {
         tags: [
-          `releasedBundles-${query.type}`,
-          'releasedBundles',
-          'allBundles',
+          cacheKeys.getReleasedBundlesByType(query.type ?? 'all'),
+          cacheKeys.RELEASED_BUNDLES,
         ],
         revalidate: 3600,
       }

--- a/modules/bundle/domain/usecases/toggleLikeBundleServerAction.ts
+++ b/modules/bundle/domain/usecases/toggleLikeBundleServerAction.ts
@@ -4,6 +4,7 @@ import { repository } from '@/modules/config/repository';
 import { revalidateTag } from 'next/cache';
 import { BundleRepository } from '../bundle.repository';
 import { getLikedBundlesServerAction } from './getLikedBundlesServerAction';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const toggleLikeBundleServerAction = async (
   userId: string | null,
@@ -31,7 +32,7 @@ export const toggleLikeBundleServerAction = async (
       await repo.likeBundle(userId, bundleId);
     }
 
-    revalidateTag(`likedBundles-${userId}`);
+    revalidateTag(cacheKeys.getLikedBundlesByUser(userId));
 
     return {
       success: true,

--- a/modules/bundle/infrastructure/bundle.prisma.repository.ts
+++ b/modules/bundle/infrastructure/bundle.prisma.repository.ts
@@ -128,7 +128,10 @@ export class BundlePrismaRepository implements BundleRepository {
   }
 
   async delete(id: number) {
-    const exist = await prisma.bundle.findFirst({ where: { id } });
+    const exist = await prisma.bundle.findFirst({
+      where: { id },
+      include: bundleIncludes,
+    });
 
     if (!exist) {
       throw new Error('Bundle이 존재하지 않습니다.');
@@ -146,6 +149,8 @@ export class BundlePrismaRepository implements BundleRepository {
       },
     });
     await prisma.bundle.delete({ where: { id } });
+
+    return toBundleDomainModel(exist);
   }
 
   async likeBundle(userId: string, bundleId: number) {

--- a/modules/config/cacheHelper.ts
+++ b/modules/config/cacheHelper.ts
@@ -1,0 +1,17 @@
+export const cacheTags = {
+  ADMIN_ALL_TRACKS: 'tag_adminAllTracks', // 어드민이 사용하는 전체 트랙
+  RELEASED_TRACK: 'tag_releasedTrack', // relaesed된 전체 트랙
+
+  getTrack: (trackId: number) => `tag_track_${trackId}`,
+
+  getLikedTracksByUser: (userId: string) => `tag_likedTracksByUser_${userId}`,
+};
+
+export const cacheKeys = {
+  ADMIN_ALL_TRACKS: 'key_adminAllTracks',
+
+  getTrack: (trackId: number) => `key_track_${trackId}`,
+  getLikedTracksByUser: (userId: string) => `key_likedTracksByUser_${userId}`,
+  getReleasedTracksByGenre: (genre: string) =>
+    `key_releasedTracksByGenre_${genre}`,
+};

--- a/modules/config/cacheHelper.ts
+++ b/modules/config/cacheHelper.ts
@@ -8,6 +8,7 @@ export const cacheTags = {
     `tag_releasedTracksByGenre_${genre}`,
 
   ALL_MOODS: 'tag_allMoods',
+  ALL_GENRES: 'tag_allGenres',
 };
 
 export const cacheKeys = {
@@ -19,4 +20,5 @@ export const cacheKeys = {
     `key_releasedTracksByGenre_${genre}`,
 
   ALL_MOODS: 'key_allMoods',
+  ALL_GENRES: 'key_allGenres',
 };

--- a/modules/config/cacheHelper.ts
+++ b/modules/config/cacheHelper.ts
@@ -3,8 +3,11 @@ export const cacheTags = {
   RELEASED_TRACK: 'tag_releasedTrack', // relaesed된 전체 트랙
 
   getTrack: (trackId: number) => `tag_track_${trackId}`,
-
   getLikedTracksByUser: (userId: string) => `tag_likedTracksByUser_${userId}`,
+  getReleasedTracksByGenre: (genre: string) =>
+    `tag_releasedTracksByGenre_${genre}`,
+
+  ALL_MOODS: 'tag_allMoods',
 };
 
 export const cacheKeys = {
@@ -14,4 +17,6 @@ export const cacheKeys = {
   getLikedTracksByUser: (userId: string) => `key_likedTracksByUser_${userId}`,
   getReleasedTracksByGenre: (genre: string) =>
     `key_releasedTracksByGenre_${genre}`,
+
+  ALL_MOODS: 'key_allMoods',
 };

--- a/modules/config/cacheHelper.ts
+++ b/modules/config/cacheHelper.ts
@@ -1,11 +1,20 @@
 export const cacheKeys = {
   ALL_MOODS: 'allMoods',
   ALL_GENRES: 'allGenres',
+  ALL_BUNDLE_TYPE: 'allBundleType',
 
   ADMIN_ALL_TRACKS: 'adminAllTracks', // 어드민이 사용하는 전체 트랙
-  RELEASED_TRACK: 'releasedTrack', // relaesed된 전체 트랙
+  RELEASED_TRACKS: 'releasedTracks', // relaesed된 전체 트랙
 
   getTrack: (trackId: number) => `track_${trackId}`,
   getLikedTracksByUser: (userId: string) => `likedTracksByUser_${userId}`,
   getReleasedTracksByGenre: (genre: string) => `releasedTracksByGenre_${genre}`,
+
+  ADMIN_ALL_BUNDLES: 'adminAllTracks', // 어드민이 사용하는 전체 번들
+  RELEASED_BUNDLES: 'releasedTrack', // relaesed된 전체 번들
+
+  getBundle: (trackId: number) => `bundle_${trackId}`,
+  getLikedBundlesByUser: (userId: string) => `likedBundlesByUser_${userId}`,
+  getReleasedBundlesByType: (bundleType: string) =>
+    `releasedBundlesByType_${bundleType}`,
 };

--- a/modules/config/cacheHelper.ts
+++ b/modules/config/cacheHelper.ts
@@ -17,4 +17,6 @@ export const cacheKeys = {
   getLikedBundlesByUser: (userId: string) => `likedBundlesByUser_${userId}`,
   getReleasedBundlesByType: (bundleType: string) =>
     `releasedBundlesByType_${bundleType}`,
+
+  getSessionUser: (userId: string) => `sessionUser_${userId}`,
 };

--- a/modules/config/cacheHelper.ts
+++ b/modules/config/cacheHelper.ts
@@ -1,24 +1,11 @@
-export const cacheTags = {
-  ADMIN_ALL_TRACKS: 'tag_adminAllTracks', // 어드민이 사용하는 전체 트랙
-  RELEASED_TRACK: 'tag_releasedTrack', // relaesed된 전체 트랙
-
-  getTrack: (trackId: number) => `tag_track_${trackId}`,
-  getLikedTracksByUser: (userId: string) => `tag_likedTracksByUser_${userId}`,
-  getReleasedTracksByGenre: (genre: string) =>
-    `tag_releasedTracksByGenre_${genre}`,
-
-  ALL_MOODS: 'tag_allMoods',
-  ALL_GENRES: 'tag_allGenres',
-};
-
 export const cacheKeys = {
-  ADMIN_ALL_TRACKS: 'key_adminAllTracks',
+  ALL_MOODS: 'allMoods',
+  ALL_GENRES: 'allGenres',
 
-  getTrack: (trackId: number) => `key_track_${trackId}`,
-  getLikedTracksByUser: (userId: string) => `key_likedTracksByUser_${userId}`,
-  getReleasedTracksByGenre: (genre: string) =>
-    `key_releasedTracksByGenre_${genre}`,
+  ADMIN_ALL_TRACKS: 'adminAllTracks', // 어드민이 사용하는 전체 트랙
+  RELEASED_TRACK: 'releasedTrack', // relaesed된 전체 트랙
 
-  ALL_MOODS: 'key_allMoods',
-  ALL_GENRES: 'key_allGenres',
+  getTrack: (trackId: number) => `track_${trackId}`,
+  getLikedTracksByUser: (userId: string) => `likedTracksByUser_${userId}`,
+  getReleasedTracksByGenre: (genre: string) => `releasedTracksByGenre_${genre}`,
 };

--- a/modules/genre/domain/usecases/createGenreServerAction.ts
+++ b/modules/genre/domain/usecases/createGenreServerAction.ts
@@ -8,6 +8,7 @@ import {
   UsecaseCreateGenreInput,
   UsecaseCreateGenreInputSchema,
 } from '../validations/CreateGenreTypes';
+import { cacheTags } from '@/modules/config/cacheHelper';
 
 export const createGenreServerAction = adminGuard(
   async (
@@ -20,7 +21,7 @@ export const createGenreServerAction = adminGuard(
 
     try {
       const genres = await repo.create({ tag, slug });
-      revalidateTag('allGenres');
+      revalidateTag(cacheTags.ALL_GENRES);
 
       return { success: true, genres };
     } catch (e) {

--- a/modules/genre/domain/usecases/createGenreServerAction.ts
+++ b/modules/genre/domain/usecases/createGenreServerAction.ts
@@ -8,7 +8,7 @@ import {
   UsecaseCreateGenreInput,
   UsecaseCreateGenreInputSchema,
 } from '../validations/CreateGenreTypes';
-import { cacheTags } from '@/modules/config/cacheHelper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const createGenreServerAction = adminGuard(
   async (
@@ -21,7 +21,7 @@ export const createGenreServerAction = adminGuard(
 
     try {
       const genres = await repo.create({ tag, slug });
-      revalidateTag(cacheTags.ALL_GENRES);
+      revalidateTag(cacheKeys.ALL_GENRES);
 
       return { success: true, genres };
     } catch (e) {

--- a/modules/genre/domain/usecases/deleteGenreServerAction.ts
+++ b/modules/genre/domain/usecases/deleteGenreServerAction.ts
@@ -4,6 +4,7 @@ import { repository } from '@/modules/config/repository';
 import { adminGuard } from '@/lib/guard/adminGuard';
 import { GenreRepository } from '../genre.repository';
 import { revalidateTag } from 'next/cache';
+import { cacheTags } from '@/modules/config/cacheHelper';
 
 export const deleteGenreServerAction = adminGuard(
   async (id: number, subGenreRepository: GenreRepository | null = null) => {
@@ -11,8 +12,9 @@ export const deleteGenreServerAction = adminGuard(
 
     try {
       await repo.delete(id);
-      revalidateTag('allGenres');
-      revalidateTag('allTracks');
+      revalidateTag(cacheTags.ALL_GENRES);
+      revalidateTag(cacheTags.ADMIN_ALL_TRACKS);
+      revalidateTag(cacheTags.RELEASED_TRACK);
 
       return { success: true };
     } catch (e) {

--- a/modules/genre/domain/usecases/deleteGenreServerAction.ts
+++ b/modules/genre/domain/usecases/deleteGenreServerAction.ts
@@ -4,7 +4,7 @@ import { repository } from '@/modules/config/repository';
 import { adminGuard } from '@/lib/guard/adminGuard';
 import { GenreRepository } from '../genre.repository';
 import { revalidateTag } from 'next/cache';
-import { cacheTags } from '@/modules/config/cacheHelper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const deleteGenreServerAction = adminGuard(
   async (id: number, subGenreRepository: GenreRepository | null = null) => {
@@ -12,9 +12,9 @@ export const deleteGenreServerAction = adminGuard(
 
     try {
       await repo.delete(id);
-      revalidateTag(cacheTags.ALL_GENRES);
-      revalidateTag(cacheTags.ADMIN_ALL_TRACKS);
-      revalidateTag(cacheTags.RELEASED_TRACK);
+      revalidateTag(cacheKeys.ALL_GENRES);
+      revalidateTag(cacheKeys.ADMIN_ALL_TRACKS);
+      revalidateTag(cacheKeys.RELEASED_TRACK);
 
       return { success: true };
     } catch (e) {

--- a/modules/genre/domain/usecases/deleteGenreServerAction.ts
+++ b/modules/genre/domain/usecases/deleteGenreServerAction.ts
@@ -14,7 +14,7 @@ export const deleteGenreServerAction = adminGuard(
       await repo.delete(id);
       revalidateTag(cacheKeys.ALL_GENRES);
       revalidateTag(cacheKeys.ADMIN_ALL_TRACKS);
-      revalidateTag(cacheKeys.RELEASED_TRACK);
+      revalidateTag(cacheKeys.RELEASED_TRACKS);
 
       return { success: true };
     } catch (e) {

--- a/modules/genre/domain/usecases/editGenreServerAction.ts
+++ b/modules/genre/domain/usecases/editGenreServerAction.ts
@@ -8,6 +8,7 @@ import {
   UsecaseEditGenreInputSchema,
 } from '../validations/EditGenreTypes';
 import { revalidateTag } from 'next/cache';
+import { cacheTags } from '@/modules/config/cacheHelper';
 
 export const editGenreServerAction = adminGuard(
   async (
@@ -34,8 +35,9 @@ export const editGenreServerAction = adminGuard(
 
     try {
       const result = await repo.edit(id, { tag, slug });
-      revalidateTag('allGenres');
-      revalidateTag('allTracks');
+      revalidateTag(cacheTags.ALL_GENRES);
+      revalidateTag(cacheTags.ADMIN_ALL_TRACKS);
+      revalidateTag(cacheTags.RELEASED_TRACK);
       return { success: true, genre: result };
     } catch (e) {
       console.error('editGenreServerAction Error', e);

--- a/modules/genre/domain/usecases/editGenreServerAction.ts
+++ b/modules/genre/domain/usecases/editGenreServerAction.ts
@@ -37,7 +37,7 @@ export const editGenreServerAction = adminGuard(
       const result = await repo.edit(id, { tag, slug });
       revalidateTag(cacheKeys.ALL_GENRES);
       revalidateTag(cacheKeys.ADMIN_ALL_TRACKS);
-      revalidateTag(cacheKeys.RELEASED_TRACK);
+      revalidateTag(cacheKeys.RELEASED_TRACKS);
       return { success: true, genre: result };
     } catch (e) {
       console.error('editGenreServerAction Error', e);

--- a/modules/genre/domain/usecases/editGenreServerAction.ts
+++ b/modules/genre/domain/usecases/editGenreServerAction.ts
@@ -8,7 +8,7 @@ import {
   UsecaseEditGenreInputSchema,
 } from '../validations/EditGenreTypes';
 import { revalidateTag } from 'next/cache';
-import { cacheTags } from '@/modules/config/cacheHelper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const editGenreServerAction = adminGuard(
   async (
@@ -35,9 +35,9 @@ export const editGenreServerAction = adminGuard(
 
     try {
       const result = await repo.edit(id, { tag, slug });
-      revalidateTag(cacheTags.ALL_GENRES);
-      revalidateTag(cacheTags.ADMIN_ALL_TRACKS);
-      revalidateTag(cacheTags.RELEASED_TRACK);
+      revalidateTag(cacheKeys.ALL_GENRES);
+      revalidateTag(cacheKeys.ADMIN_ALL_TRACKS);
+      revalidateTag(cacheKeys.RELEASED_TRACK);
       return { success: true, genre: result };
     } catch (e) {
       console.error('editGenreServerAction Error', e);

--- a/modules/genre/domain/usecases/getAllGenresServerAction.ts
+++ b/modules/genre/domain/usecases/getAllGenresServerAction.ts
@@ -3,6 +3,7 @@
 import { repository } from '@/modules/config/repository';
 import { GenreRepository } from '../genre.repository';
 import { unstable_cache } from 'next/cache';
+import { cacheKeys, cacheTags } from '@/modules/config/cacheHelper';
 
 export const getAllGenresServerAction = async (
   subGenreRepository: GenreRepository | null = null
@@ -13,11 +14,11 @@ export const getAllGenresServerAction = async (
     const genres = unstable_cache(
       async () => {
         const data = await repo.getAll();
-        console.log(`Prisma 호출 : allGenres`);
+        console.log(`Prisma 호출 : ${cacheKeys.ALL_GENRES}`);
         return data;
       },
-      [`allGenres`],
-      { tags: [`allGenres`], revalidate: 3600 }
+      [cacheKeys.ALL_GENRES],
+      { tags: [cacheTags.ALL_GENRES], revalidate: 3600 }
     )();
     return genres;
   } catch (e) {

--- a/modules/genre/domain/usecases/getAllGenresServerAction.ts
+++ b/modules/genre/domain/usecases/getAllGenresServerAction.ts
@@ -3,7 +3,7 @@
 import { repository } from '@/modules/config/repository';
 import { GenreRepository } from '../genre.repository';
 import { unstable_cache } from 'next/cache';
-import { cacheKeys, cacheTags } from '@/modules/config/cacheHelper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const getAllGenresServerAction = async (
   subGenreRepository: GenreRepository | null = null
@@ -18,7 +18,7 @@ export const getAllGenresServerAction = async (
         return data;
       },
       [cacheKeys.ALL_GENRES],
-      { tags: [cacheTags.ALL_GENRES], revalidate: 3600 }
+      { tags: [cacheKeys.ALL_GENRES], revalidate: 3600 }
     )();
     return genres;
   } catch (e) {

--- a/modules/mood/domain/usecases/createMoodServerAction.ts
+++ b/modules/mood/domain/usecases/createMoodServerAction.ts
@@ -8,6 +8,7 @@ import {
   UsecaseCreateMoodInputSchema,
 } from '../validations/CreateMoodTypes';
 import { revalidateTag } from 'next/cache';
+import { cacheTags } from '@/modules/config/cacheHelper';
 
 export const createMoodServerAction = adminGuard(
   async (
@@ -19,7 +20,7 @@ export const createMoodServerAction = adminGuard(
 
     try {
       const mood = await repo.create({ tag });
-      revalidateTag('allMoods');
+      revalidateTag(cacheTags.ALL_MOODS);
 
       return { success: true, mood };
     } catch (e) {

--- a/modules/mood/domain/usecases/createMoodServerAction.ts
+++ b/modules/mood/domain/usecases/createMoodServerAction.ts
@@ -8,7 +8,7 @@ import {
   UsecaseCreateMoodInputSchema,
 } from '../validations/CreateMoodTypes';
 import { revalidateTag } from 'next/cache';
-import { cacheTags } from '@/modules/config/cacheHelper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const createMoodServerAction = adminGuard(
   async (
@@ -20,7 +20,7 @@ export const createMoodServerAction = adminGuard(
 
     try {
       const mood = await repo.create({ tag });
-      revalidateTag(cacheTags.ALL_MOODS);
+      revalidateTag(cacheKeys.ALL_MOODS);
 
       return { success: true, mood };
     } catch (e) {

--- a/modules/mood/domain/usecases/deleteMoodServerAction.ts
+++ b/modules/mood/domain/usecases/deleteMoodServerAction.ts
@@ -4,6 +4,7 @@ import { repository } from '@/modules/config/repository';
 import { adminGuard } from '@/lib/guard/adminGuard';
 import { MoodRepository } from '@/modules/mood/domain/mood.repository';
 import { revalidateTag } from 'next/cache';
+import { cacheTags } from '@/modules/config/cacheHelper';
 
 export const deleteMoodServerAction = adminGuard(
   async (id: number, subMoodRepository: MoodRepository | null = null) => {
@@ -11,8 +12,9 @@ export const deleteMoodServerAction = adminGuard(
 
     try {
       await repo.delete(id);
-      revalidateTag('allMoods');
-      revalidateTag('allTracks');
+      revalidateTag(cacheTags.ALL_MOODS);
+      revalidateTag(cacheTags.RELEASED_TRACK);
+      revalidateTag(cacheTags.ADMIN_ALL_TRACKS);
 
       return { success: true };
     } catch (e) {

--- a/modules/mood/domain/usecases/deleteMoodServerAction.ts
+++ b/modules/mood/domain/usecases/deleteMoodServerAction.ts
@@ -4,7 +4,7 @@ import { repository } from '@/modules/config/repository';
 import { adminGuard } from '@/lib/guard/adminGuard';
 import { MoodRepository } from '@/modules/mood/domain/mood.repository';
 import { revalidateTag } from 'next/cache';
-import { cacheTags } from '@/modules/config/cacheHelper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const deleteMoodServerAction = adminGuard(
   async (id: number, subMoodRepository: MoodRepository | null = null) => {
@@ -12,9 +12,9 @@ export const deleteMoodServerAction = adminGuard(
 
     try {
       await repo.delete(id);
-      revalidateTag(cacheTags.ALL_MOODS);
-      revalidateTag(cacheTags.RELEASED_TRACK);
-      revalidateTag(cacheTags.ADMIN_ALL_TRACKS);
+      revalidateTag(cacheKeys.ALL_MOODS);
+      revalidateTag(cacheKeys.RELEASED_TRACK);
+      revalidateTag(cacheKeys.ADMIN_ALL_TRACKS);
 
       return { success: true };
     } catch (e) {

--- a/modules/mood/domain/usecases/deleteMoodServerAction.ts
+++ b/modules/mood/domain/usecases/deleteMoodServerAction.ts
@@ -13,7 +13,7 @@ export const deleteMoodServerAction = adminGuard(
     try {
       await repo.delete(id);
       revalidateTag(cacheKeys.ALL_MOODS);
-      revalidateTag(cacheKeys.RELEASED_TRACK);
+      revalidateTag(cacheKeys.RELEASED_TRACKS);
       revalidateTag(cacheKeys.ADMIN_ALL_TRACKS);
 
       return { success: true };

--- a/modules/mood/domain/usecases/editMoodServerAction.ts
+++ b/modules/mood/domain/usecases/editMoodServerAction.ts
@@ -8,7 +8,7 @@ import {
   UsecaseEditMoodInputSchema,
 } from '../validations/EditMoodTypes';
 import { revalidateTag } from 'next/cache';
-import { cacheTags } from '@/modules/config/cacheHelper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const editMoodServerAction = adminGuard(
   async (
@@ -36,9 +36,9 @@ export const editMoodServerAction = adminGuard(
 
     try {
       const result = await repo.edit(id, { tag });
-      revalidateTag(cacheTags.ALL_MOODS);
-      revalidateTag(cacheTags.RELEASED_TRACK);
-      revalidateTag(cacheTags.ADMIN_ALL_TRACKS);
+      revalidateTag(cacheKeys.ALL_MOODS);
+      revalidateTag(cacheKeys.RELEASED_TRACK);
+      revalidateTag(cacheKeys.ADMIN_ALL_TRACKS);
 
       return { success: true, mood: result };
     } catch (e) {

--- a/modules/mood/domain/usecases/editMoodServerAction.ts
+++ b/modules/mood/domain/usecases/editMoodServerAction.ts
@@ -8,6 +8,7 @@ import {
   UsecaseEditMoodInputSchema,
 } from '../validations/EditMoodTypes';
 import { revalidateTag } from 'next/cache';
+import { cacheTags } from '@/modules/config/cacheHelper';
 
 export const editMoodServerAction = adminGuard(
   async (
@@ -35,8 +36,9 @@ export const editMoodServerAction = adminGuard(
 
     try {
       const result = await repo.edit(id, { tag });
-      revalidateTag('allMoods');
-      revalidateTag('allTracks');
+      revalidateTag(cacheTags.ALL_MOODS);
+      revalidateTag(cacheTags.RELEASED_TRACK);
+      revalidateTag(cacheTags.ADMIN_ALL_TRACKS);
 
       return { success: true, mood: result };
     } catch (e) {

--- a/modules/mood/domain/usecases/editMoodServerAction.ts
+++ b/modules/mood/domain/usecases/editMoodServerAction.ts
@@ -37,7 +37,7 @@ export const editMoodServerAction = adminGuard(
     try {
       const result = await repo.edit(id, { tag });
       revalidateTag(cacheKeys.ALL_MOODS);
-      revalidateTag(cacheKeys.RELEASED_TRACK);
+      revalidateTag(cacheKeys.RELEASED_TRACKS);
       revalidateTag(cacheKeys.ADMIN_ALL_TRACKS);
 
       return { success: true, mood: result };

--- a/modules/mood/domain/usecases/getAllMoodsServerAction.ts
+++ b/modules/mood/domain/usecases/getAllMoodsServerAction.ts
@@ -3,7 +3,7 @@
 import { unstable_cache } from 'next/cache';
 import { repository } from '@/modules/config/repository';
 import { MoodRepository } from '../mood.repository';
-import { cacheKeys, cacheTags } from '@/modules/config/cacheHelper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const getAllMoodsServerAction = async (
   subMoodRepository: MoodRepository | null = null
@@ -18,7 +18,7 @@ export const getAllMoodsServerAction = async (
         return data;
       },
       [cacheKeys.ALL_MOODS],
-      { tags: [cacheTags.ALL_MOODS], revalidate: 3600 }
+      { tags: [cacheKeys.ALL_MOODS], revalidate: 3600 }
     )();
     return moods;
   } catch (e) {

--- a/modules/mood/domain/usecases/getAllMoodsServerAction.ts
+++ b/modules/mood/domain/usecases/getAllMoodsServerAction.ts
@@ -3,6 +3,7 @@
 import { unstable_cache } from 'next/cache';
 import { repository } from '@/modules/config/repository';
 import { MoodRepository } from '../mood.repository';
+import { cacheKeys, cacheTags } from '@/modules/config/cacheHelper';
 
 export const getAllMoodsServerAction = async (
   subMoodRepository: MoodRepository | null = null
@@ -13,11 +14,11 @@ export const getAllMoodsServerAction = async (
     const moods = unstable_cache(
       async () => {
         const data = await repo.getAll();
-        console.log(`Prisma 호출 : allMoods`);
+        console.log(`Prisma 호출 : ${cacheKeys.ALL_MOODS}`);
         return data;
       },
-      [`allMoods`],
-      { tags: [`allMoods`], revalidate: 3600 }
+      [cacheKeys.ALL_MOODS],
+      { tags: [cacheTags.ALL_MOODS], revalidate: 3600 }
     )();
     return moods;
   } catch (e) {

--- a/modules/stem/domain/stem.repository.ts
+++ b/modules/stem/domain/stem.repository.ts
@@ -3,5 +3,5 @@ import { RepositoryCreateStemInput } from './validations/CreateStemTypes';
 
 export interface StemRepository {
   create: (data: RepositoryCreateStemInput) => Promise<DomainStem>;
-  delete: (id: number) => Promise<number | null>;
+  delete: (id: number) => Promise<DomainStem>;
 }

--- a/modules/stem/infrastructure/stem.prisma.repository.ts
+++ b/modules/stem/infrastructure/stem.prisma.repository.ts
@@ -28,6 +28,6 @@ export class StemPrismaRepository implements StemRepository {
 
     await prisma.stem.delete({ where: { id } });
 
-    return exist.trackId;
+    return toStemDomainModel(exist);
   }
 }

--- a/modules/track/domain/usecases/createTrackServerAction.ts
+++ b/modules/track/domain/usecases/createTrackServerAction.ts
@@ -8,7 +8,7 @@ import {
   UsecaseCreateTrackInputSchema,
 } from '../validations/CreateTrackTypes';
 import { TrackRepository } from '../track.repository';
-import { TrackStatus } from '../track';
+import { cacheTags } from '@/modules/config/cacheHelper';
 
 export const createTrackServerAction = adminGuard(
   async (
@@ -20,13 +20,8 @@ export const createTrackServerAction = adminGuard(
 
     try {
       const track = await repo.create(parsedData);
-      revalidateTag('allTracks');
-      if (track.status === TrackStatus.PUBLISH) {
-        revalidateTag(`releasedTracks-all`);
-        track.genres.forEach((genre) => {
-          revalidateTag(`releasedTracks-${genre.slug}`);
-        });
-      }
+
+      revalidateTag(cacheTags.ADMIN_ALL_TRACKS);
 
       return { success: true, track };
     } catch (e) {

--- a/modules/track/domain/usecases/createTrackServerAction.ts
+++ b/modules/track/domain/usecases/createTrackServerAction.ts
@@ -8,7 +8,7 @@ import {
   UsecaseCreateTrackInputSchema,
 } from '../validations/CreateTrackTypes';
 import { TrackRepository } from '../track.repository';
-import { cacheTags } from '@/modules/config/cacheHelper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const createTrackServerAction = adminGuard(
   async (
@@ -21,7 +21,7 @@ export const createTrackServerAction = adminGuard(
     try {
       const track = await repo.create(parsedData);
 
-      revalidateTag(cacheTags.ADMIN_ALL_TRACKS);
+      revalidateTag(cacheKeys.ADMIN_ALL_TRACKS);
 
       return { success: true, track };
     } catch (e) {

--- a/modules/track/domain/usecases/deleteTrackServerAction.ts
+++ b/modules/track/domain/usecases/deleteTrackServerAction.ts
@@ -4,7 +4,7 @@ import { repository } from '@/modules/config/repository';
 import { adminGuard } from '@/lib/guard/adminGuard';
 import { TrackRepository } from '@/modules/track/domain/track.repository';
 import { revalidateTag } from 'next/cache';
-import { cacheTags } from '@/modules/config/cacheHelper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 import { TrackStatus } from '../track';
 
 export const deleteTrackServerAction = adminGuard(
@@ -14,10 +14,10 @@ export const deleteTrackServerAction = adminGuard(
     try {
       const exist = await repo.delete(id);
 
-      revalidateTag(cacheTags.ADMIN_ALL_TRACKS);
+      revalidateTag(cacheKeys.ADMIN_ALL_TRACKS);
 
       if (exist.status === TrackStatus.PUBLISH) {
-        revalidateTag(cacheTags.RELEASED_TRACK);
+        revalidateTag(cacheKeys.RELEASED_TRACK);
       }
 
       return { success: true };

--- a/modules/track/domain/usecases/deleteTrackServerAction.ts
+++ b/modules/track/domain/usecases/deleteTrackServerAction.ts
@@ -17,7 +17,7 @@ export const deleteTrackServerAction = adminGuard(
       revalidateTag(cacheKeys.ADMIN_ALL_TRACKS);
 
       if (exist.status === TrackStatus.PUBLISH) {
-        revalidateTag(cacheKeys.RELEASED_TRACK);
+        revalidateTag(cacheKeys.RELEASED_TRACKS);
       }
 
       return { success: true };

--- a/modules/track/domain/usecases/deleteTrackServerAction.ts
+++ b/modules/track/domain/usecases/deleteTrackServerAction.ts
@@ -4,19 +4,21 @@ import { repository } from '@/modules/config/repository';
 import { adminGuard } from '@/lib/guard/adminGuard';
 import { TrackRepository } from '@/modules/track/domain/track.repository';
 import { revalidateTag } from 'next/cache';
+import { cacheTags } from '@/modules/config/cacheHelper';
+import { TrackStatus } from '../track';
 
 export const deleteTrackServerAction = adminGuard(
   async (id: number, subTrackRepository: TrackRepository | null = null) => {
     const repo = subTrackRepository || repository.track;
 
     try {
-      const deletedTrack = await repo.delete(id);
-      revalidateTag('allTracks');
-      revalidateTag(`track-${id}`);
-      revalidateTag(`releasedTracks-all`);
-      deletedTrack.genres.forEach((genre) => {
-        revalidateTag(`releasedTracks-${genre.slug}`);
-      });
+      const exist = await repo.delete(id);
+
+      revalidateTag(cacheTags.ADMIN_ALL_TRACKS);
+
+      if (exist.status === TrackStatus.PUBLISH) {
+        revalidateTag(cacheTags.RELEASED_TRACK);
+      }
 
       return { success: true };
     } catch (e) {

--- a/modules/track/domain/usecases/editTrackServerAction.ts
+++ b/modules/track/domain/usecases/editTrackServerAction.ts
@@ -9,7 +9,7 @@ import {
 } from '../validations/EditTrackTypes';
 import { TrackRepository } from '../track.repository';
 import { arraysEqual } from '@/lib/utils';
-import { cacheTags } from '@/modules/config/cacheHelper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 import { TrackStatus } from '../track';
 
 export const editTrackServerAction = adminGuard(
@@ -65,14 +65,14 @@ export const editTrackServerAction = adminGuard(
     try {
       const result = await repo.edit(id, updatedField);
 
-      revalidateTag(cacheTags.ADMIN_ALL_TRACKS);
+      revalidateTag(cacheKeys.ADMIN_ALL_TRACKS);
 
       // status가 publish 였거나 publish 로 수정될때만 releasedTrack 캐시 무효화
       if (
         exist.status === TrackStatus.PUBLISH ||
         result.status === TrackStatus.PUBLISH
       ) {
-        revalidateTag(cacheTags.RELEASED_TRACK);
+        revalidateTag(cacheKeys.RELEASED_TRACK);
       }
 
       return { success: true, track: result };

--- a/modules/track/domain/usecases/editTrackServerAction.ts
+++ b/modules/track/domain/usecases/editTrackServerAction.ts
@@ -66,13 +66,19 @@ export const editTrackServerAction = adminGuard(
       const result = await repo.edit(id, updatedField);
 
       revalidateTag(cacheKeys.ADMIN_ALL_TRACKS);
+      revalidateTag(cacheKeys.getTrack(result.id));
 
       // status가 publish 였거나 publish 로 수정될때만 releasedTrack 캐시 무효화
       if (
         exist.status === TrackStatus.PUBLISH ||
         result.status === TrackStatus.PUBLISH
       ) {
-        revalidateTag(cacheKeys.RELEASED_TRACK);
+        revalidateTag(cacheKeys.getReleasedTracksByGenre('all'));
+        const _genres = new Set([...exist.genres, ...result.genres]);
+
+        _genres.forEach((t) =>
+          revalidateTag(cacheKeys.getReleasedTracksByGenre(t.slug))
+        );
       }
 
       return { success: true, track: result };

--- a/modules/track/domain/usecases/getAllTracksServerAction.ts
+++ b/modules/track/domain/usecases/getAllTracksServerAction.ts
@@ -3,6 +3,7 @@
 import { repository } from '@/modules/config/repository';
 import { TrackRepository } from '../track.repository';
 import { unstable_cache } from 'next/cache';
+import { cacheKeys, cacheTags } from '@/modules/config/cacheHelper';
 
 // 페이지 네이션 필요
 export const getAllTracksServerAction = async (
@@ -11,16 +12,16 @@ export const getAllTracksServerAction = async (
   const repo = subTrackRepository || repository.track;
 
   try {
-    const tracks = unstable_cache(
+    const allTracks = await unstable_cache(
       async () => {
         const data = await repo.findAll();
-        console.log(`Prisma 호출 : allTracks`);
+        console.log(`Prisma 호출: ${cacheKeys.ADMIN_ALL_TRACKS}`);
         return data;
       },
-      [`allTracks`],
-      { tags: [`allTracks`], revalidate: 3600 }
+      [cacheKeys.ADMIN_ALL_TRACKS],
+      { tags: [cacheTags.ADMIN_ALL_TRACKS], revalidate: 3600 }
     )();
-    return tracks;
+    return allTracks;
   } catch (e) {
     console.error('getAllTracksServerAction Error: ', e);
     return [];

--- a/modules/track/domain/usecases/getAllTracksServerAction.ts
+++ b/modules/track/domain/usecases/getAllTracksServerAction.ts
@@ -3,7 +3,7 @@
 import { repository } from '@/modules/config/repository';
 import { TrackRepository } from '../track.repository';
 import { unstable_cache } from 'next/cache';
-import { cacheKeys, cacheTags } from '@/modules/config/cacheHelper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 // 페이지 네이션 필요
 export const getAllTracksServerAction = async (
@@ -19,7 +19,7 @@ export const getAllTracksServerAction = async (
         return data;
       },
       [cacheKeys.ADMIN_ALL_TRACKS],
-      { tags: [cacheTags.ADMIN_ALL_TRACKS], revalidate: 3600 }
+      { tags: [cacheKeys.ADMIN_ALL_TRACKS], revalidate: 3600 }
     )();
     return allTracks;
   } catch (e) {

--- a/modules/track/domain/usecases/getLikedTracksServerAction.ts
+++ b/modules/track/domain/usecases/getLikedTracksServerAction.ts
@@ -3,6 +3,7 @@
 import { repository } from '@/modules/config/repository';
 import { TrackRepository } from '../track.repository';
 import { unstable_cache } from 'next/cache';
+import { cacheKeys, cacheTags } from '@/modules/config/cacheHelper';
 
 // 페이지 네이션 필요
 export const getLikedTracksServerAction = async (
@@ -17,12 +18,12 @@ export const getLikedTracksServerAction = async (
     const likedTracks = await unstable_cache(
       async () => {
         const data = await repo.getLikedTracksByUser(userId);
-        console.log(`Prisma 호출 : likedTracks-${userId}`);
+        console.log(`Prisma 호출: ${cacheKeys.getLikedTracksByUser(userId)}`);
         return data;
       },
-      [`likedTracks-${userId}`],
+      [cacheKeys.getLikedTracksByUser(userId)],
       {
-        tags: [`likedTracks-${userId}`],
+        tags: [cacheTags.getLikedTracksByUser(userId)],
         revalidate: 3600,
       }
     )();

--- a/modules/track/domain/usecases/getLikedTracksServerAction.ts
+++ b/modules/track/domain/usecases/getLikedTracksServerAction.ts
@@ -3,7 +3,7 @@
 import { repository } from '@/modules/config/repository';
 import { TrackRepository } from '../track.repository';
 import { unstable_cache } from 'next/cache';
-import { cacheKeys, cacheTags } from '@/modules/config/cacheHelper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 // 페이지 네이션 필요
 export const getLikedTracksServerAction = async (
@@ -23,7 +23,7 @@ export const getLikedTracksServerAction = async (
       },
       [cacheKeys.getLikedTracksByUser(userId)],
       {
-        tags: [cacheTags.getLikedTracksByUser(userId)],
+        tags: [cacheKeys.getLikedTracksByUser(userId)],
         revalidate: 3600,
       }
     )();

--- a/modules/track/domain/usecases/getReleasedTracksServerAction.ts
+++ b/modules/track/domain/usecases/getReleasedTracksServerAction.ts
@@ -4,6 +4,7 @@ import { repository } from '@/modules/config/repository';
 import { TrackRepository } from '../track.repository';
 import { unstable_cache } from 'next/cache';
 import { RepositoryGetTracksQuery } from '../validations/GetTrackTypes';
+import { cacheKeys, cacheTags } from '@/modules/config/cacheHelper';
 
 export const getReleasedTracksServerAction = async (
   query: Pick<RepositoryGetTracksQuery, 'genre'>,
@@ -20,12 +21,16 @@ export const getReleasedTracksServerAction = async (
           count: 12,
         });
 
-        console.log(`Prisma 호출 : releasedTracks-${query.genre}`);
+        console.log(
+          `Prisma 호출: ${cacheKeys.getReleasedTracksByGenre(
+            query.genre ?? ''
+          )}`
+        );
         return data;
       },
-      [`releasedTracks-${query.genre}`, 'releasedTracks', 'allTracks'],
+      [cacheKeys.getReleasedTracksByGenre(query.genre ?? '')],
       {
-        tags: [`releasedTracks-${query.genre}`, 'releasedTracks', 'allTracks'],
+        tags: [cacheTags.RELEASED_TRACK],
         revalidate: 3600,
       }
     )();

--- a/modules/track/domain/usecases/getReleasedTracksServerAction.ts
+++ b/modules/track/domain/usecases/getReleasedTracksServerAction.ts
@@ -4,7 +4,7 @@ import { repository } from '@/modules/config/repository';
 import { TrackRepository } from '../track.repository';
 import { unstable_cache } from 'next/cache';
 import { RepositoryGetTracksQuery } from '../validations/GetTrackTypes';
-import { cacheKeys, cacheTags } from '@/modules/config/cacheHelper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const getReleasedTracksServerAction = async (
   query: Pick<RepositoryGetTracksQuery, 'genre'>,
@@ -30,7 +30,7 @@ export const getReleasedTracksServerAction = async (
       },
       [cacheKeys.getReleasedTracksByGenre(query.genre ?? '')],
       {
-        tags: [cacheTags.RELEASED_TRACK],
+        tags: [cacheKeys.RELEASED_TRACK],
         revalidate: 3600,
       }
     )();

--- a/modules/track/domain/usecases/getReleasedTracksServerAction.ts
+++ b/modules/track/domain/usecases/getReleasedTracksServerAction.ts
@@ -30,7 +30,10 @@ export const getReleasedTracksServerAction = async (
       },
       [cacheKeys.getReleasedTracksByGenre(query.genre ?? '')],
       {
-        tags: [cacheKeys.RELEASED_TRACK],
+        tags: [
+          cacheKeys.RELEASED_TRACKS,
+          cacheKeys.getReleasedTracksByGenre(query.genre ?? 'all'),
+        ],
         revalidate: 3600,
       }
     )();

--- a/modules/track/domain/usecases/getTrackServerAction.ts
+++ b/modules/track/domain/usecases/getTrackServerAction.ts
@@ -3,7 +3,7 @@
 import { repository } from '@/modules/config/repository';
 import { TrackRepository } from '../track.repository';
 import { unstable_cache } from 'next/cache';
-import { cacheKeys, cacheTags } from '@/modules/config/cacheHelper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 // 페이지 네이션 필요
 export const getTrackServerAction = async (
@@ -21,7 +21,7 @@ export const getTrackServerAction = async (
       },
       [cacheKeys.getTrack(trackId)],
       {
-        tags: [cacheTags.getTrack(trackId), cacheTags.ADMIN_ALL_TRACKS],
+        tags: [cacheKeys.getTrack(trackId), cacheKeys.ADMIN_ALL_TRACKS],
         revalidate: 3600,
       }
     )();

--- a/modules/track/domain/usecases/getTrackServerAction.ts
+++ b/modules/track/domain/usecases/getTrackServerAction.ts
@@ -3,6 +3,7 @@
 import { repository } from '@/modules/config/repository';
 import { TrackRepository } from '../track.repository';
 import { unstable_cache } from 'next/cache';
+import { cacheKeys, cacheTags } from '@/modules/config/cacheHelper';
 
 // 페이지 네이션 필요
 export const getTrackServerAction = async (
@@ -15,11 +16,14 @@ export const getTrackServerAction = async (
     const track = await unstable_cache(
       async () => {
         const data = await repo.findById(trackId);
-        console.log(`Prisma 호출 : track-${trackId}`);
+        console.log(`Prisma 호출: ${cacheKeys.getTrack(trackId)}`);
         return data;
       },
-      [`track-${trackId}`, 'allTracks'],
-      { tags: [`track-${trackId}`, 'allTracks'], revalidate: 3600 }
+      [cacheKeys.getTrack(trackId)],
+      {
+        tags: [cacheTags.getTrack(trackId), cacheTags.ADMIN_ALL_TRACKS],
+        revalidate: 3600,
+      }
     )();
 
     return track;

--- a/modules/track/domain/usecases/getTrackServerAction.ts
+++ b/modules/track/domain/usecases/getTrackServerAction.ts
@@ -21,7 +21,7 @@ export const getTrackServerAction = async (
       },
       [cacheKeys.getTrack(trackId)],
       {
-        tags: [cacheKeys.getTrack(trackId), cacheKeys.ADMIN_ALL_TRACKS],
+        tags: [cacheKeys.getTrack(trackId)],
         revalidate: 3600,
       }
     )();

--- a/modules/track/domain/usecases/toggleLikeTrackServerAction.ts
+++ b/modules/track/domain/usecases/toggleLikeTrackServerAction.ts
@@ -4,7 +4,7 @@ import { repository } from '@/modules/config/repository';
 import { TrackRepository } from '../track.repository';
 import { revalidateTag } from 'next/cache';
 import { getLikedTracksServerAction } from './getLikedTracksServerAction';
-import { cacheTags } from '@/modules/config/cacheHelper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const toggleLikeTrackServerAction = async (
   userId: string | null,
@@ -33,7 +33,7 @@ export const toggleLikeTrackServerAction = async (
       await repo.likeTrack(userId, trackId);
     }
 
-    revalidateTag(cacheTags.getLikedTracksByUser(userId));
+    revalidateTag(cacheKeys.getLikedTracksByUser(userId));
 
     return {
       success: true,

--- a/modules/track/domain/usecases/toggleLikeTrackServerAction.ts
+++ b/modules/track/domain/usecases/toggleLikeTrackServerAction.ts
@@ -4,6 +4,7 @@ import { repository } from '@/modules/config/repository';
 import { TrackRepository } from '../track.repository';
 import { revalidateTag } from 'next/cache';
 import { getLikedTracksServerAction } from './getLikedTracksServerAction';
+import { cacheTags } from '@/modules/config/cacheHelper';
 
 export const toggleLikeTrackServerAction = async (
   userId: string | null,
@@ -32,7 +33,7 @@ export const toggleLikeTrackServerAction = async (
       await repo.likeTrack(userId, trackId);
     }
 
-    revalidateTag(`likedTracks-${userId}`);
+    revalidateTag(cacheTags.getLikedTracksByUser(userId));
 
     return {
       success: true,

--- a/modules/track/infrastructure/track.prisma.repository.ts
+++ b/modules/track/infrastructure/track.prisma.repository.ts
@@ -60,6 +60,9 @@ export class TrackPrismaRepository implements TrackRepository {
         ...whereCondition,
         status: 'PUBLISH',
       },
+      orderBy: {
+        id: 'desc',
+      },
       include: trackIncludes,
       skip: offset,
       take: count,

--- a/modules/user/domain/usecases/editUserServerAction.ts
+++ b/modules/user/domain/usecases/editUserServerAction.ts
@@ -10,6 +10,7 @@ import {
   UsecaseEditUserInputSchema,
 } from '../validations/EditUserTypes';
 import { toUserDomainModel } from '../../infrastructure/user.prisma.mapper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const editUserServerAction = userGuard(
   async (
@@ -37,7 +38,7 @@ export const editUserServerAction = userGuard(
 
     try {
       const result = await repo.edit(id, updatedField);
-      revalidateTag(`sessionUser-${id}`);
+      revalidateTag(cacheKeys.getSessionUser(id));
       return { success: true, user: result };
     } catch (e) {
       console.error('Edit User Error: ', e);

--- a/modules/user/domain/usecases/getSessionUserServerAction.ts
+++ b/modules/user/domain/usecases/getSessionUserServerAction.ts
@@ -8,6 +8,7 @@ import { UserRepository } from '../user.repository';
 import { authOptions } from '@/api/auth/[...nextauth]/route';
 import { SessionUser } from '../user';
 import { toSessionUserDomainModel } from '../../infrastructure/user.prisma.mapper';
+import { cacheKeys } from '@/modules/config/cacheHelper';
 
 export const getSessionUserServerAction = async (
   subUserRepository: UserRepository | null = null
@@ -24,15 +25,17 @@ export const getSessionUserServerAction = async (
           session.user.id,
           toSessionUserDomainModel
         );
-        console.log(`Prisma 호출 : sessionUser-${session.user.id}`);
+        console.log(
+          `Prisma 호출: ${cacheKeys.getSessionUser(session.user.id)}`
+        );
         return data;
       },
-      [`sessionUser-${session.user.id}`],
-      { tags: [`sessionUser-${session.user.id}`], revalidate: 3600 }
+      [cacheKeys.getSessionUser(session.user.id)],
+      { tags: [cacheKeys.getSessionUser(session.user.id)], revalidate: 3600 }
     )();
     return user;
   } catch (e) {
-    console.log('GetSessionUser Error: ', e);
+    console.log('getSessionUserServerAction Error: ', e);
     return null;
   }
 };


### PR DESCRIPTION
modules/config/cacheHelper.ts - 캐시 키 모음

- 각 fetch usecases에 연관된 keys를 tags로 가지고 데이터 변경이 일어날 경우 관련된 tags를 업데이트
- 서비스 로직 실행 후 무효화 해야 할 태그를 쉽게 찾기 위하여 한객체에 중앙화

태깅 ex) relasedTracks_{genre}일 경우 [releasedTracks_{genre}, allReleasedTracks] 과 같이 해당 캐시 키와 필요 시 관련된 상위 그룹을 태그값에 포함

로직 실행 ex) editTrack 실행 시
  1. admin all tracks - 어드민이 사용하는 모든 트랙 리스트
  2. getTrack(id) - 해당 트랙
  3. 데이터 변경 전/후 에 status가 publish 일 경우
    - getReleasedTracksByGenre("all") - all로 요청한 releasedTracks
    - getReleasedTracksByGenre(...track.genres) - 변경 전/후의 genres 모아 중복을 제거하여 관련된 캐시 무효화
