### PR TITLE
@feature/tracks page

### DIFF
--- a/app/(auth)/ClosePlayerTrigger.tsx
+++ b/app/(auth)/ClosePlayerTrigger.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { useUIStatusStore } from '@/store/useUIStatusStorage';
+import { useEffect } from 'react';
+
+export const ClosePlayerTrigger = () => {
+  const closePlayer = useUIStatusStore((state) => state.closePlayer);
+
+  useEffect(() => {
+    closePlayer();
+  }, [closePlayer]);
+
+  return null;
+};

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,5 +1,6 @@
 import { getSessionUserServerAction } from '@/modules/user/domain/usecases/getSessionUserServerAction';
 import { redirect } from 'next/navigation';
+import { ClosePlayerTrigger } from './ClosePlayerTrigger';
 
 export default async function AuthLayout({
   children,
@@ -11,5 +12,10 @@ export default async function AuthLayout({
   if (user) {
     redirect('/');
   }
-  return <div>{children}</div>;
+  return (
+    <div>
+      {children}
+      <ClosePlayerTrigger />
+    </div>
+  );
 }

--- a/app/(main)/_component/ReleasedTrackList.tsx
+++ b/app/(main)/_component/ReleasedTrackList.tsx
@@ -3,12 +3,12 @@ import { Genre } from '@/modules/genre/domain/genre';
 import { getReleasedTracksServerAction } from '@/modules/track/domain/usecases/getReleasedTracksServerAction';
 
 interface Props {
-  genre: Genre | 'all';
+  genre?: Genre;
 }
 
 export const RelasedTrackList = async ({ genre }: Props) => {
-  const tracks = await getReleasedTracksServerAction({
-    genre: genre === 'all' ? 'all' : genre.slug,
+  const { tracks } = await getReleasedTracksServerAction({
+    genre: genre?.slug,
   });
 
   return <TrackCarousel tracks={tracks} />;

--- a/app/(main)/_component/ReleasedTrackList.tsx
+++ b/app/(main)/_component/ReleasedTrackList.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export const RelasedTrackList = async ({ genre }: Props) => {
   const { tracks } = await getReleasedTracksServerAction({
-    genre: genre?.slug,
+    genres: genre ? [genre.id] : undefined,
   });
 
   return <TrackCarousel tracks={tracks} />;

--- a/app/(main)/_component/ReleasedTrackSection.tsx
+++ b/app/(main)/_component/ReleasedTrackSection.tsx
@@ -41,7 +41,7 @@ export const ReleasedTrackSection = ({ genres }: Props) => {
         </TabsList>
         <TabsContent key={'all'} value={'all'}>
           <Suspense fallback={<div>Loading...</div>}>
-            <RelasedTrackList genre={'all'} />
+            <RelasedTrackList />
           </Suspense>
         </TabsContent>
         {genres.map((genre) => {

--- a/app/(main)/community/page.tsx
+++ b/app/(main)/community/page.tsx
@@ -1,7 +1,7 @@
 export default function CommunityPage() {
   return (
     <div className="flex flex-col items-center justify-between">
-      <div>Community</div>
+      <div>Tracks</div>
     </div>
   );
 }

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -12,7 +12,7 @@ const mainSidebarNavItems = [
     title: '탐색',
   },
   {
-    href: '/sounds',
+    href: '/tracks',
     icon: <Music className="h-4 w-4" />,
     title: '트랙',
   },

--- a/app/(main)/sounds/page.tsx
+++ b/app/(main)/sounds/page.tsx
@@ -1,7 +1,0 @@
-export default function SoundsPage() {
-  return (
-    <div className="flex flex-col items-center justify-between">
-      <div>Sounds</div>
-    </div>
-  );
-}

--- a/app/(main)/tracks/Pagination.tsx
+++ b/app/(main)/tracks/Pagination.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
-import { ChevronLeft, ChevronsLeft } from 'lucide-react';
+import { ChevronsLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
 interface Props {
@@ -37,6 +37,7 @@ export const Pagination = ({ totalItems, take, page }: Props) => {
     for (let i = startPage; i <= endPage; ++i) {
       pages.push(
         <Button
+          key={i}
           variant={page === i ? 'default' : 'outline'}
           className="w-10 h-10 p-0"
           onClick={() => router.push(`/tracks?page=${i}`)}
@@ -49,33 +50,31 @@ export const Pagination = ({ totalItems, take, page }: Props) => {
     return pages;
   };
   return (
-    <div className="w-full flex items-center justify-center">
-      <div className="w-full max-w-lg flex items-center gap-1">
-        {3 < page ? (
-          <>
-            <Button
-              variant={'outline'}
-              onClick={() => router.push(`/tracks?page=${1}`)}
-              className="w-10 h-10 p-0"
-            >
-              <ChevronsLeft className="w-4 h-4" />
-            </Button>
-          </>
-        ) : null}
-        {renderPageNumbers()}
-        {page + 3 <= totalPages ? (
-          <>
-            <div className="px-2">...</div>
-            <Button
-              className="w-10 h-10 p-0"
-              variant={page === totalPages ? 'default' : 'outline'}
-              onClick={() => router.push(`/tracks?page=${totalPages}`)}
-            >
-              {totalPages}
-            </Button>
-          </>
-        ) : null}
-      </div>
+    <div className="w-full flex items-center justify-center gap-1">
+      {3 < page ? (
+        <>
+          <Button
+            variant={'outline'}
+            onClick={() => router.push(`/tracks?page=${1}`)}
+            className="w-10 h-10 p-0"
+          >
+            <ChevronsLeft className="w-4 h-4" />
+          </Button>
+        </>
+      ) : null}
+      {renderPageNumbers()}
+      {page + 3 <= totalPages ? (
+        <>
+          <div className="px-2">...</div>
+          <Button
+            className="w-10 h-10 p-0"
+            variant={page === totalPages ? 'default' : 'outline'}
+            onClick={() => router.push(`/tracks?page=${totalPages}`)}
+          >
+            {totalPages}
+          </Button>
+        </>
+      ) : null}
     </div>
   );
 };

--- a/app/(main)/tracks/Pagination.tsx
+++ b/app/(main)/tracks/Pagination.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { ChevronLeft, ChevronsLeft } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+interface Props {
+  totalItems: number;
+  take: number;
+  page: number;
+}
+
+export const Pagination = ({ totalItems, take, page }: Props) => {
+  const router = useRouter();
+  const totalPages = Math.ceil(totalItems / take);
+  const renderPageNumbers = () => {
+    const pages = [];
+
+    let startPage = 0;
+    let endPage = 0;
+    if (totalPages <= 5) {
+      startPage = 1;
+      endPage = totalPages;
+    } else {
+      if (page <= 3) {
+        startPage = 1;
+        endPage = 5;
+      } else if (page + 2 >= totalPages) {
+        startPage = totalPages - 4;
+        endPage = totalPages;
+      } else {
+        startPage = page - 2;
+        endPage = page + 2;
+      }
+    }
+
+    for (let i = startPage; i <= endPage; ++i) {
+      pages.push(
+        <Button
+          variant={page === i ? 'default' : 'outline'}
+          className="w-10 h-10 p-0"
+          onClick={() => router.push(`/tracks?page=${i}`)}
+        >
+          {i}
+        </Button>
+      );
+    }
+
+    return pages;
+  };
+  return (
+    <div className="w-full flex items-center justify-center">
+      <div className="w-full max-w-lg flex items-center gap-1">
+        {3 < page ? (
+          <>
+            <Button
+              variant={'outline'}
+              onClick={() => router.push(`/tracks?page=${1}`)}
+              className="w-10 h-10 p-0"
+            >
+              <ChevronsLeft className="w-4 h-4" />
+            </Button>
+          </>
+        ) : null}
+        {renderPageNumbers()}
+        {page + 3 <= totalPages ? (
+          <>
+            <div className="px-2">...</div>
+            <Button
+              className="w-10 h-10 p-0"
+              variant={page === totalPages ? 'default' : 'outline'}
+              onClick={() => router.push(`/tracks?page=${totalPages}`)}
+            >
+              {totalPages}
+            </Button>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+};

--- a/app/(main)/tracks/Pagination.tsx
+++ b/app/(main)/tracks/Pagination.tsx
@@ -3,31 +3,29 @@
 import { Button } from '@/components/ui/button';
 import { ChevronsLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { TracksSearchParams } from './page';
+import { createTracksQueryString } from '@/lib/queryString';
 
 interface Props {
   totalItems: number;
   take: number;
   page: number;
-  searchParams?: TracksSearchParams;
+
+  selectedGenres: number[];
+  selectedMoods: number[];
+  title?: string;
 }
 
-export const Pagination = ({ totalItems, take, page, searchParams }: Props) => {
+export const Pagination = ({
+  totalItems,
+  take,
+  page,
+  title,
+  selectedGenres,
+  selectedMoods,
+}: Props) => {
   const router = useRouter();
   const totalPages = Math.ceil(totalItems / take);
 
-  const createQueryString = (page: number) => {
-    const query = [];
-    if (searchParams?.genres && searchParams.genres.length)
-      query.push(`genres=${searchParams.genres}`);
-    if (searchParams?.moods && searchParams.moods.length)
-      query.push(`moods=${searchParams.moods}`);
-    if (searchParams?.title)
-      query.push(`title=${encodeURIComponent(searchParams.title)}`);
-    if (page) query.push(`page=${page}`);
-
-    return query.join('&');
-  };
   const renderPageNumbers = () => {
     const pages = [];
 
@@ -55,7 +53,16 @@ export const Pagination = ({ totalItems, take, page, searchParams }: Props) => {
           key={i}
           variant={page === i ? 'default' : 'outline'}
           className="w-10 h-10 p-0"
-          onClick={() => router.push(`/tracks?${createQueryString(i)}`)}
+          onClick={() =>
+            router.push(
+              `/tracks?${createTracksQueryString({
+                page: i,
+                title,
+                genreIds: selectedGenres,
+                moodIds: selectedMoods,
+              })}`
+            )
+          }
         >
           {i}
         </Button>
@@ -70,7 +77,16 @@ export const Pagination = ({ totalItems, take, page, searchParams }: Props) => {
         <>
           <Button
             variant={'outline'}
-            onClick={() => router.push(`/tracks?${createQueryString(1)}`)}
+            onClick={() =>
+              router.push(
+                `/tracks?${createTracksQueryString({
+                  page: 1,
+                  title,
+                  genreIds: selectedGenres,
+                  moodIds: selectedMoods,
+                })}`
+              )
+            }
             className="w-10 h-10 p-0"
           >
             <ChevronsLeft className="w-4 h-4" />
@@ -85,7 +101,14 @@ export const Pagination = ({ totalItems, take, page, searchParams }: Props) => {
             className="w-10 h-10 p-0"
             variant={page === totalPages ? 'default' : 'outline'}
             onClick={() =>
-              router.push(`/tracks?${createQueryString(totalPages)}`)
+              router.push(
+                `/tracks?${createTracksQueryString({
+                  page: totalPages,
+                  title,
+                  genreIds: selectedGenres,
+                  moodIds: selectedMoods,
+                })}`
+              )
             }
           >
             {totalPages}

--- a/app/(main)/tracks/Pagination.tsx
+++ b/app/(main)/tracks/Pagination.tsx
@@ -3,16 +3,31 @@
 import { Button } from '@/components/ui/button';
 import { ChevronsLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
+import { TracksSearchParams } from './page';
 
 interface Props {
   totalItems: number;
   take: number;
   page: number;
+  searchParams?: TracksSearchParams;
 }
 
-export const Pagination = ({ totalItems, take, page }: Props) => {
+export const Pagination = ({ totalItems, take, page, searchParams }: Props) => {
   const router = useRouter();
   const totalPages = Math.ceil(totalItems / take);
+
+  const createQueryString = (page: number) => {
+    const query = [];
+    if (searchParams?.genres && searchParams.genres.length)
+      query.push(`genres=${searchParams.genres}`);
+    if (searchParams?.moods && searchParams.moods.length)
+      query.push(`moods=${searchParams.moods}`);
+    if (searchParams?.title)
+      query.push(`title=${encodeURIComponent(searchParams.title)}`);
+    if (page) query.push(`page=${page}`);
+
+    return query.join('&');
+  };
   const renderPageNumbers = () => {
     const pages = [];
 
@@ -40,7 +55,7 @@ export const Pagination = ({ totalItems, take, page }: Props) => {
           key={i}
           variant={page === i ? 'default' : 'outline'}
           className="w-10 h-10 p-0"
-          onClick={() => router.push(`/tracks?page=${i}`)}
+          onClick={() => router.push(`/tracks?${createQueryString(i)}`)}
         >
           {i}
         </Button>
@@ -55,7 +70,7 @@ export const Pagination = ({ totalItems, take, page }: Props) => {
         <>
           <Button
             variant={'outline'}
-            onClick={() => router.push(`/tracks?page=${1}`)}
+            onClick={() => router.push(`/tracks?${createQueryString(1)}`)}
             className="w-10 h-10 p-0"
           >
             <ChevronsLeft className="w-4 h-4" />
@@ -69,7 +84,9 @@ export const Pagination = ({ totalItems, take, page }: Props) => {
           <Button
             className="w-10 h-10 p-0"
             variant={page === totalPages ? 'default' : 'outline'}
-            onClick={() => router.push(`/tracks?page=${totalPages}`)}
+            onClick={() =>
+              router.push(`/tracks?${createQueryString(totalPages)}`)
+            }
           >
             {totalPages}
           </Button>

--- a/app/(main)/tracks/TrackFilter.tsx
+++ b/app/(main)/tracks/TrackFilter.tsx
@@ -1,0 +1,165 @@
+'use client';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useAppStore } from '@/store/useAppStore';
+import { TracksSearchParams } from './page';
+import { useRouter } from 'next/navigation';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  selectedGenres: number[];
+  selectedMoods: number[];
+  searchParams?: TracksSearchParams;
+}
+
+export const TrackFilter = ({
+  selectedGenres,
+  selectedMoods,
+  searchParams,
+}: Props) => {
+  const route = useRouter();
+  const { genres, moods } = useAppStore((state) => ({
+    genres: state.genres,
+    moods: state.moods,
+  }));
+  const createQueryString = ({
+    genreIds,
+    moodIds,
+  }: {
+    genreIds: number[];
+    moodIds: number[];
+  }) => {
+    const query = [];
+    if (genreIds) query.push(`genres=[${genreIds}]`);
+    if (moodIds) query.push(`moods=[${moodIds}]`);
+    if (searchParams?.title)
+      query.push(`title=${encodeURIComponent(searchParams.title)}`);
+    if (searchParams?.page) query.push(`page=${searchParams.page}`);
+
+    return query.join('&');
+  };
+
+  const onClickToggleGenre = (id: number) => {
+    try {
+      // 만약 queryString에 유효하지 않은 genre.id가 존재한다면 없애줌
+      const _selectedGenres = selectedGenres.filter((item) =>
+        genres.find((genre) => genre.id === item)
+      );
+      const query = createQueryString({
+        genreIds: _selectedGenres.includes(id)
+          ? _selectedGenres.filter((selectedId) => selectedId !== id)
+          : [id, ..._selectedGenres],
+        moodIds: selectedMoods,
+      });
+
+      route.push(`/tracks?${query}`);
+    } catch (e) {
+      console.log('Error toggling filter', e);
+    }
+  };
+
+  const onClickToggleMood = (id: number) => {
+    try {
+      // 만약 queryString에 유효하지 않은 genre.id가 존재한다면 없애줌
+      const _selectedMoods = selectedMoods.filter((item) =>
+        moods.find((mood) => mood.id === item)
+      );
+      const query = createQueryString({
+        genreIds: selectedGenres,
+        moodIds: _selectedMoods.includes(id)
+          ? _selectedMoods.filter((selectedId) => selectedId !== id)
+          : [id, ..._selectedMoods],
+      });
+
+      route.push(`/tracks?${query}`);
+    } catch (e) {
+      console.log('Error toggling filter', e);
+    }
+  };
+  const onClickClearFilter = () => {
+    try {
+      const query = createQueryString({
+        genreIds: [],
+        moodIds: [],
+      });
+
+      route.push(`/tracks?${query}`);
+    } catch (e) {
+      console.log('Error toggling filter', e);
+    }
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Filter</Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80">
+        <Tabs defaultValue="genres" className="w-full">
+          <TabsList className="grid w-full grid-cols-2 bg-background">
+            <TabsTrigger value="genres">Genres</TabsTrigger>
+            <TabsTrigger value="moods">Moods</TabsTrigger>
+          </TabsList>
+          <TabsContent value="genres">
+            <ul className="flex flex-wrap gap-1">
+              {genres.map((genre) => {
+                const isSelected =
+                  selectedGenres && selectedGenres.includes(genre.id);
+                return (
+                  <li
+                    key={genre.id}
+                    onClick={() => onClickToggleGenre(genre.id)}
+                  >
+                    <Badge
+                      variant={isSelected ? 'default' : 'outline'}
+                      className={cn(
+                        'cursor-pointer',
+                        !isSelected && 'hover:bg-muted'
+                      )}
+                    >
+                      {genre.tag}
+                    </Badge>
+                  </li>
+                );
+              })}
+            </ul>
+          </TabsContent>
+          <TabsContent value="moods">
+            <ul className="flex flex-wrap gap-1">
+              {moods.map((mood) => {
+                const isSelected =
+                  selectedMoods && selectedMoods.includes(mood.id);
+                return (
+                  <li key={mood.id} onClick={() => onClickToggleMood(mood.id)}>
+                    <Badge
+                      variant={isSelected ? 'default' : 'outline'}
+                      className={cn(
+                        'cursor-pointer',
+                        !isSelected && 'hover:bg-muted'
+                      )}
+                    >
+                      {mood.tag}
+                    </Badge>
+                  </li>
+                );
+              })}
+            </ul>
+          </TabsContent>
+        </Tabs>
+        <Button
+          onClick={() => onClickClearFilter()}
+          className="w-full mt-4 text-sm h-8"
+          variant="ghost"
+        >
+          Clear
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/app/(main)/tracks/TrackFilter.tsx
+++ b/app/(main)/tracks/TrackFilter.tsx
@@ -40,21 +40,17 @@ export const TrackFilter = ({
     if (moodIds) query.push(`moods=[${moodIds}]`);
     if (searchParams?.title)
       query.push(`title=${encodeURIComponent(searchParams.title)}`);
-    if (searchParams?.page) query.push(`page=${searchParams.page}`);
+    query.push(`page=${1}`);
 
     return query.join('&');
   };
 
   const onClickToggleGenre = (id: number) => {
     try {
-      // 만약 queryString에 유효하지 않은 genre.id가 존재한다면 없애줌
-      const _selectedGenres = selectedGenres.filter((item) =>
-        genres.find((genre) => genre.id === item)
-      );
       const query = createQueryString({
-        genreIds: _selectedGenres.includes(id)
-          ? _selectedGenres.filter((selectedId) => selectedId !== id)
-          : [id, ..._selectedGenres],
+        genreIds: selectedGenres.includes(id)
+          ? selectedGenres.filter((selectedId) => selectedId !== id)
+          : [id, ...selectedGenres],
         moodIds: selectedMoods,
       });
 
@@ -66,15 +62,11 @@ export const TrackFilter = ({
 
   const onClickToggleMood = (id: number) => {
     try {
-      // 만약 queryString에 유효하지 않은 genre.id가 존재한다면 없애줌
-      const _selectedMoods = selectedMoods.filter((item) =>
-        moods.find((mood) => mood.id === item)
-      );
       const query = createQueryString({
         genreIds: selectedGenres,
-        moodIds: _selectedMoods.includes(id)
-          ? _selectedMoods.filter((selectedId) => selectedId !== id)
-          : [id, ..._selectedMoods],
+        moodIds: selectedMoods.includes(id)
+          ? selectedMoods.filter((selectedId) => selectedId !== id)
+          : [id, ...selectedMoods],
       });
 
       route.push(`/tracks?${query}`);

--- a/app/(main)/tracks/TrackFilter.tsx
+++ b/app/(main)/tracks/TrackFilter.tsx
@@ -8,50 +8,35 @@ import {
 } from '@/components/ui/popover';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useAppStore } from '@/store/useAppStore';
-import { TracksSearchParams } from './page';
 import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
+import { createTracksQueryString } from '@/lib/queryString';
 
 interface Props {
   selectedGenres: number[];
   selectedMoods: number[];
-  searchParams?: TracksSearchParams;
+  title?: string;
 }
 
 export const TrackFilter = ({
   selectedGenres,
   selectedMoods,
-  searchParams,
+  title,
 }: Props) => {
   const route = useRouter();
   const { genres, moods } = useAppStore((state) => ({
     genres: state.genres,
     moods: state.moods,
   }));
-  const createQueryString = ({
-    genreIds,
-    moodIds,
-  }: {
-    genreIds: number[];
-    moodIds: number[];
-  }) => {
-    const query = [];
-    if (genreIds) query.push(`genres=[${genreIds}]`);
-    if (moodIds) query.push(`moods=[${moodIds}]`);
-    if (searchParams?.title)
-      query.push(`title=${encodeURIComponent(searchParams.title)}`);
-    query.push(`page=${1}`);
-
-    return query.join('&');
-  };
 
   const onClickToggleGenre = (id: number) => {
     try {
-      const query = createQueryString({
+      const query = createTracksQueryString({
         genreIds: selectedGenres.includes(id)
           ? selectedGenres.filter((selectedId) => selectedId !== id)
           : [id, ...selectedGenres],
         moodIds: selectedMoods,
+        title,
       });
 
       route.push(`/tracks?${query}`);
@@ -62,11 +47,12 @@ export const TrackFilter = ({
 
   const onClickToggleMood = (id: number) => {
     try {
-      const query = createQueryString({
+      const query = createTracksQueryString({
         genreIds: selectedGenres,
         moodIds: selectedMoods.includes(id)
           ? selectedMoods.filter((selectedId) => selectedId !== id)
           : [id, ...selectedMoods],
+        title,
       });
 
       route.push(`/tracks?${query}`);
@@ -76,9 +62,10 @@ export const TrackFilter = ({
   };
   const onClickClearFilter = () => {
     try {
-      const query = createQueryString({
+      const query = createTracksQueryString({
         genreIds: [],
         moodIds: [],
+        title: '',
       });
 
       route.push(`/tracks?${query}`);

--- a/app/(main)/tracks/TrackList.tsx
+++ b/app/(main)/tracks/TrackList.tsx
@@ -1,0 +1,91 @@
+'use client';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { formatSeconds } from '@/lib/dateFormat';
+import { Track } from '@/modules/track/domain/track';
+import { Play } from 'lucide-react';
+import Image from 'next/image';
+
+interface Props {
+  tracks: Track[];
+}
+export const TrackList = ({ tracks }: Props) => {
+  return (
+    <div>
+      <div className="w-full py-2 px-2 space-x-4 flex items-center rounded-md text-sm">
+        <p className="w-full">track</p>
+        <p className="w-20 shrink-0 hidden lg:block">length</p>
+        <p className="w-16 shrink-0 hidden lg:block">bpm</p>
+        <p className="w-32 shrink-0 hidden lg:block">key</p>
+      </div>
+      <ul>
+        {tracks.map((track) => {
+          return (
+            <li
+              key={track.id}
+              className="w-full py-2 px-2 space-x-4 flex items-center rounded-md text-sm cursor-pointer duration-200 hover:bg-muted"
+            >
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      className="rounded-full hover:bg-background w-10 h-10 p-0 shrink-0"
+                      variant="ghost"
+                    >
+                      <Play className="w-4 h-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Play</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+
+              <Image
+                src={track.imageUrl}
+                width={200}
+                height={200}
+                alt={track.title}
+                className="w-10 h-10 rounded-md aspect-square"
+              />
+              <div className="w-full space-y-1">
+                <p className="break-all line-clamp-1">{track.title}</p>
+                <div className="flex items-center gap-2 flex-wrap">
+                  {track.genres.map((genre) => {
+                    return (
+                      <Badge
+                        key={genre.id}
+                        variant="outline"
+                        className="text-xs py-0.5 px-2"
+                      >
+                        {genre.tag}
+                      </Badge>
+                    );
+                  })}
+                  {track.moods.map((mood) => {
+                    return (
+                      <Badge key={mood.id} variant="secondary">
+                        {mood.tag}
+                      </Badge>
+                    );
+                  })}
+                </div>
+              </div>
+              <p className="w-20 shrink-0 hidden lg:block">
+                {formatSeconds(track.length)}
+              </p>
+              <p className="w-16 shrink-0 hidden lg:block">{track.bpm}</p>
+              <p className="w-32 shrink-0 hidden lg:block">{track.key}</p>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};

--- a/app/(main)/tracks/TrackList.tsx
+++ b/app/(main)/tracks/TrackList.tsx
@@ -1,18 +1,9 @@
 'use client';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
-import { formatSeconds } from '@/lib/dateFormat';
 import { createTracksQueryString } from '@/lib/queryString';
 import { Track } from '@/modules/track/domain/track';
-import { Play } from 'lucide-react';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import { TrackListItem } from './TrackListItem';
 
 interface Props {
   tracks: Track[];
@@ -54,64 +45,7 @@ export const TrackList = ({ tracks }: Props) => {
       </div>
       <ul>
         {tracks.map((track) => {
-          return (
-            <li
-              key={track.id}
-              className="w-full py-2 px-2 space-x-4 flex items-center rounded-md text-sm cursor-pointer duration-200 hover:bg-muted"
-            >
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      className="rounded-full hover:bg-background w-10 h-10 p-0 shrink-0"
-                      variant="ghost"
-                    >
-                      <Play className="w-4 h-4" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>Play</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-
-              <Image
-                src={track.imageUrl}
-                width={200}
-                height={200}
-                alt={track.title}
-                className="w-10 h-10 rounded-md aspect-square"
-              />
-              <div className="w-full space-y-1">
-                <p className="break-all line-clamp-1">{track.title}</p>
-                <div className="flex items-center gap-2 flex-wrap">
-                  {track.genres.map((genre) => {
-                    return (
-                      <Badge
-                        key={genre.id}
-                        variant="outline"
-                        className="text-xs py-0.5 px-2"
-                      >
-                        {genre.tag}
-                      </Badge>
-                    );
-                  })}
-                  {track.moods.map((mood) => {
-                    return (
-                      <Badge key={mood.id} variant="secondary">
-                        {mood.tag}
-                      </Badge>
-                    );
-                  })}
-                </div>
-              </div>
-              <p className="w-20 shrink-0 hidden lg:block">
-                {formatSeconds(track.length)}
-              </p>
-              <p className="w-16 shrink-0 hidden lg:block">{track.bpm}</p>
-              <p className="w-32 shrink-0 hidden lg:block">{track.key}</p>
-            </li>
-          );
+          return <TrackListItem key={track.id} track={track} />;
         })}
       </ul>
     </div>

--- a/app/(main)/tracks/TrackList.tsx
+++ b/app/(main)/tracks/TrackList.tsx
@@ -8,14 +8,42 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { formatSeconds } from '@/lib/dateFormat';
+import { createTracksQueryString } from '@/lib/queryString';
 import { Track } from '@/modules/track/domain/track';
 import { Play } from 'lucide-react';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
 interface Props {
   tracks: Track[];
 }
 export const TrackList = ({ tracks }: Props) => {
+  const router = useRouter();
+  const onClickClearFilter = () => {
+    try {
+      const query = createTracksQueryString({
+        genreIds: [],
+        moodIds: [],
+        title: '',
+      });
+
+      router.push(`/tracks?${query}`);
+    } catch (e) {
+      console.log('Error toggling filter', e);
+    }
+  };
+
+  if (tracks.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-4 space-y-2">
+        <p className="text-xl">😢 일치하는 트랙이 없습니다.</p>
+        <p className="text-muted-foreground">
+          더 적은 수의 필터를 사용해보세요.
+        </p>
+        <Button onClick={() => onClickClearFilter()}>Clear Filter</Button>
+      </div>
+    );
+  }
   return (
     <div>
       <div className="w-full py-2 px-2 space-x-4 flex items-center rounded-md text-sm">

--- a/app/(main)/tracks/TrackListItem.tsx
+++ b/app/(main)/tracks/TrackListItem.tsx
@@ -1,0 +1,129 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { formatSeconds } from '@/lib/dateFormat';
+import { cn } from '@/lib/utils';
+import { Track } from '@/modules/track/domain/track';
+import { usePlayerStore } from '@/store/usePlayerStore';
+import { Pause, Play } from 'lucide-react';
+import Image from 'next/image';
+
+interface Props {
+  track: Track;
+}
+
+export const TrackListItem = ({ track }: Props) => {
+  const [
+    currentTrack,
+    isPlaying,
+    setIsPlaying,
+    selectedBundleId,
+    setTrack,
+    playlistName,
+    playlist,
+    playlistId,
+    setPlaylist,
+  ] = usePlayerStore((state) => [
+    state.currentTrack,
+    state.isPlaying,
+    state.setIsPlaying,
+    state.selectedBundleId,
+    state.setTrack,
+    state.playlistName,
+    state.playlist,
+    state.playlistId,
+    state.setPlaylist,
+  ]);
+
+  const isSelectedTrack =
+    selectedBundleId === '' && currentTrack && currentTrack.id === track.id;
+
+  const onTrackClick = () => {
+    // 이미 선택 된 트랙이라면 isPlaying 토글
+    if (isSelectedTrack) {
+      setIsPlaying(!isPlaying);
+      return;
+    }
+
+    if (playlistId === '') {
+      // 현재 선택 된 플레이리스트가 없는 경우
+      setPlaylist('custom', 'custom', [track]);
+    } else {
+      setPlaylist(playlistId, playlistName, [
+        ...playlist.filter((item) => item.id !== track.id),
+        track,
+      ]);
+    }
+    setTrack(track);
+  };
+  return (
+    <li className="w-full py-2 px-2 space-x-4 flex items-center rounded-md text-sm cursor-pointer duration-200 hover:bg-muted">
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              className="rounded-full hover:bg-primary hover:text-primary-foreground hover:dark:bg-background hover:dark:text-foreground  w-10 h-10 p-0 shrink-0"
+              variant="ghost"
+              onClick={() => onTrackClick()}
+            >
+              {isSelectedTrack && isPlaying ? (
+                <Pause className={cn('w-4 h-4', isSelectedTrack && 'block')} />
+              ) : (
+                <Play
+                  className={cn(
+                    'w-4 h-4',
+                    isSelectedTrack && isPlaying && 'block'
+                  )}
+                />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Play</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+
+      <Image
+        src={track.imageUrl}
+        width={200}
+        height={200}
+        alt={track.title}
+        className="w-10 h-10 rounded-md aspect-square"
+      />
+      <div className="w-full space-y-1">
+        <p className="break-all line-clamp-1">{track.title}</p>
+        <div className="flex items-center gap-2 flex-wrap">
+          {track.genres.map((genre) => {
+            return (
+              <Badge
+                key={genre.id}
+                variant="outline"
+                className="text-xs py-0.5 px-2"
+              >
+                {genre.tag}
+              </Badge>
+            );
+          })}
+          {track.moods.map((mood) => {
+            return (
+              <Badge key={mood.id} variant="secondary">
+                {mood.tag}
+              </Badge>
+            );
+          })}
+        </div>
+      </div>
+      <p className="w-20 shrink-0 hidden lg:block">
+        {formatSeconds(track.length)}
+      </p>
+      <p className="w-16 shrink-0 hidden lg:block">{track.bpm}</p>
+      <p className="w-32 shrink-0 hidden lg:block">{track.key}</p>
+    </li>
+  );
+};

--- a/app/(main)/tracks/TrackSearchBar.tsx
+++ b/app/(main)/tracks/TrackSearchBar.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Search, X } from 'lucide-react';
+import { TracksSearchParams } from './page';
+import { useRouter } from 'next/navigation';
+import { useAppStore } from '@/store/useAppStore';
+import { Badge } from '@/components/ui/badge';
+
+interface Props {
+  selectedGenres: number[];
+  selectedMoods: number[];
+  searchParams?: TracksSearchParams;
+}
+
+export const TrackSearchBar = ({
+  selectedGenres,
+  selectedMoods,
+  searchParams,
+}: Props) => {
+  const { genres, moods } = useAppStore((state) => ({
+    genres: state.genres,
+    moods: state.moods,
+  }));
+  const [searchQuery, setSearchQuery] = useState('');
+  const router = useRouter();
+
+  const createQueryString = ({
+    title,
+    genreIds,
+    moodIds,
+  }: {
+    title?: string;
+    genreIds?: number[];
+    moodIds?: number[];
+  }) => {
+    const query = [];
+    query.push(`page=${1}`);
+    query.push(`genres=[${genreIds ? genreIds : selectedGenres}]`);
+    query.push(`moods=[${moodIds ? moodIds : selectedMoods}]`);
+    if (title) query.push(`title=${encodeURIComponent(title)}`);
+
+    return query.join('&');
+  };
+
+  const handleSearch = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      router.push(`/tracks?${createQueryString({ title: searchQuery })}`);
+    }
+  };
+
+  const onClickRemoveGenre = (id: number) => {
+    try {
+      const query = createQueryString({
+        genreIds: selectedGenres.filter((selectedId) => selectedId !== id),
+        moodIds: selectedMoods,
+      });
+
+      router.push(`/tracks?${query}`);
+    } catch (e) {
+      console.log('Error toggling filter', e);
+    }
+  };
+  const onClickRemoveMood = (id: number) => {
+    try {
+      const query = createQueryString({
+        genreIds: selectedGenres,
+        moodIds: selectedMoods.filter((selectedId) => selectedId !== id),
+      });
+
+      router.push(`/tracks?${query}`);
+    } catch (e) {
+      console.log('Error toggling filter', e);
+    }
+  };
+
+  return (
+    <div className="w-full">
+      <div className="relative flex items-center w-full">
+        <Search className="absolute left-2 w-4 h-4" />
+        <Input
+          className="h-10 max-w-xl pl-8 text-md"
+          placeholder="Search title"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          onKeyDown={handleSearch}
+        />
+      </div>
+      <ul className="flex flex-wrap gap-2 pt-2">
+        {genres.map((genre) => {
+          if (!selectedGenres.includes(genre.id)) return null;
+          return (
+            <li
+              key={genre.id}
+              className="cursor-pointer"
+              onClick={() => onClickRemoveGenre(genre.id)}
+            >
+              <Badge className="flex items-center space-x-1">
+                {genre.tag} <X className="w-4 h-4" />
+              </Badge>
+            </li>
+          );
+        })}
+        {moods.map((mood) => {
+          if (!selectedMoods.includes(mood.id)) return null;
+          return (
+            <li
+              key={mood.id}
+              className="cursor-pointer"
+              onClick={() => onClickRemoveMood(mood.id)}
+            >
+              <Badge
+                variant="secondary"
+                className="flex items-center space-x-1"
+              >
+                {mood.tag} <X className="w-4 h-4" />
+              </Badge>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};

--- a/app/(main)/tracks/TrackSearchBar.tsx
+++ b/app/(main)/tracks/TrackSearchBar.tsx
@@ -3,56 +3,45 @@
 import { useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Search, X } from 'lucide-react';
-import { TracksSearchParams } from './page';
 import { useRouter } from 'next/navigation';
 import { useAppStore } from '@/store/useAppStore';
 import { Badge } from '@/components/ui/badge';
+import { createTracksQueryString } from '@/lib/queryString';
 
 interface Props {
   selectedGenres: number[];
   selectedMoods: number[];
-  searchParams?: TracksSearchParams;
+  title?: string;
 }
 
 export const TrackSearchBar = ({
+  title,
   selectedGenres,
   selectedMoods,
-  searchParams,
 }: Props) => {
   const { genres, moods } = useAppStore((state) => ({
     genres: state.genres,
     moods: state.moods,
   }));
-  const [searchQuery, setSearchQuery] = useState('');
+  const [searchQuery, setSearchQuery] = useState(title ? title : '');
   const router = useRouter();
-
-  const createQueryString = ({
-    title,
-    genreIds,
-    moodIds,
-  }: {
-    title?: string;
-    genreIds?: number[];
-    moodIds?: number[];
-  }) => {
-    const query = [];
-    query.push(`page=${1}`);
-    query.push(`genres=[${genreIds ? genreIds : selectedGenres}]`);
-    query.push(`moods=[${moodIds ? moodIds : selectedMoods}]`);
-    if (title) query.push(`title=${encodeURIComponent(title)}`);
-
-    return query.join('&');
-  };
 
   const handleSearch = (event: React.KeyboardEvent) => {
     if (event.key === 'Enter') {
-      router.push(`/tracks?${createQueryString({ title: searchQuery })}`);
+      router.push(
+        `/tracks?${createTracksQueryString({
+          title: searchQuery,
+          genreIds: selectedGenres,
+          moodIds: selectedMoods,
+        })}`
+      );
     }
   };
 
   const onClickRemoveGenre = (id: number) => {
     try {
-      const query = createQueryString({
+      const query = createTracksQueryString({
+        title,
         genreIds: selectedGenres.filter((selectedId) => selectedId !== id),
         moodIds: selectedMoods,
       });
@@ -64,7 +53,8 @@ export const TrackSearchBar = ({
   };
   const onClickRemoveMood = (id: number) => {
     try {
-      const query = createQueryString({
+      const query = createTracksQueryString({
+        title,
         genreIds: selectedGenres,
         moodIds: selectedMoods.filter((selectedId) => selectedId !== id),
       });

--- a/app/(main)/tracks/page.tsx
+++ b/app/(main)/tracks/page.tsx
@@ -5,15 +5,39 @@ import { Button } from '@/components/ui/button';
 import { Pagination } from './Pagination';
 import { getReleasedTracksServerAction } from '@/modules/track/domain/usecases/getReleasedTracksServerAction';
 
+export interface TracksSearchParams {
+  page?: string;
+  title?: string;
+  genres?: string[];
+  moods?: string[];
+}
+
 export default async function TracksPage({
   searchParams,
 }: {
-  searchParams?: { [key: string]: string | string[] | undefined };
+  searchParams?: TracksSearchParams;
 }) {
   const page = Number(searchParams?.page);
+  const title = searchParams?.title ? searchParams.title.toString() : undefined;
+  let genres = [];
+  let moods = [];
+  try {
+    genres = JSON.parse(searchParams?.genres?.toString() || '[]');
+  } catch (e) {
+    genres = [];
+  }
+  try {
+    moods = JSON.parse(searchParams?.moods?.toString() || '[]');
+  } catch (e) {
+    moods = [];
+  }
   const { tracks, count } = await getReleasedTracksServerAction({
     page: isNaN(page) ? 1 : page,
+    genres,
+    moods,
+    title: title,
   });
+
   return (
     <div className="flex flex-col items-center justify-between px-4">
       <div className="w-full max-w-screen-xl py-16 space-y-8">
@@ -35,6 +59,7 @@ export default async function TracksPage({
           totalItems={count}
           take={10}
           page={isNaN(page) ? 1 : page}
+          searchParams={searchParams}
         />
       </div>
     </div>

--- a/app/(main)/tracks/page.tsx
+++ b/app/(main)/tracks/page.tsx
@@ -40,9 +40,9 @@ export default async function TracksPage({
 
   return (
     <div className="flex flex-col items-center justify-between px-4">
-      <div className="w-full max-w-screen-xl py-16 space-y-8">
+      <div className="w-full max-w-screen-xl py-16 space-y-2">
         <div className="text-5xl font-semibold">Search</div>
-        <div className="flex items-center justify-between py-4">
+        <div className="flex items-start justify-between gap-2 py-4">
           <TrackSearchBar
             selectedGenres={selectedGenres}
             selectedMoods={selectedMoods}
@@ -54,6 +54,8 @@ export default async function TracksPage({
             title={title}
           />
         </div>
+        <p>{count} results</p>
+
         <TrackList tracks={tracks} />
         <Pagination
           totalItems={count}

--- a/app/(main)/tracks/page.tsx
+++ b/app/(main)/tracks/page.tsx
@@ -4,6 +4,7 @@ import { getReleasedTracksServerAction } from '@/modules/track/domain/usecases/g
 import { TrackFilter } from './TrackFilter';
 import { useAppStore } from '@/store/useAppStore';
 import { TrackSearchBar } from './TrackSearchBar';
+import { parseStringToArrayNumber } from '@/lib/queryString';
 
 export interface TracksSearchParams {
   page?: string;
@@ -21,25 +22,12 @@ export default async function TracksPage({
   const moods = useAppStore.getState().moods;
   const page = Number(searchParams?.page);
   const title = searchParams?.title ? searchParams.title.toString() : undefined;
-  const parseArrayParam = (param?: string | string[]): number[] => {
-    if (!param) return [];
-    if (Array.isArray(param)) {
-      return param.map(Number).filter((item) => !isNaN(item));
-    }
-    try {
-      const parsed = JSON.parse(param);
-      return Array.isArray(parsed)
-        ? parsed.map(Number).filter((item) => !isNaN(item))
-        : [];
-    } catch (e) {
-      return [];
-    }
-  };
+
   // 유효하지 않은 태그는 필터링
-  const selectedGenres = parseArrayParam(searchParams?.genres).filter(
+  const selectedGenres = parseStringToArrayNumber(searchParams?.genres).filter(
     (selectedId) => genres.find((genre) => genre.id === selectedId)
   );
-  const selectedMoods = parseArrayParam(searchParams?.moods).filter(
+  const selectedMoods = parseStringToArrayNumber(searchParams?.moods).filter(
     (selectedId) => moods.find((mood) => mood.id === selectedId)
   );
 
@@ -56,14 +44,14 @@ export default async function TracksPage({
         <div className="text-5xl font-semibold">Search</div>
         <div className="flex items-center justify-between py-4">
           <TrackSearchBar
-            searchParams={searchParams}
             selectedGenres={selectedGenres}
             selectedMoods={selectedMoods}
+            title={title}
           />
           <TrackFilter
             selectedGenres={selectedGenres}
             selectedMoods={selectedMoods}
-            searchParams={searchParams}
+            title={title}
           />
         </div>
         <TrackList tracks={tracks} />
@@ -71,7 +59,9 @@ export default async function TracksPage({
           totalItems={count}
           take={10}
           page={isNaN(page) ? 1 : page}
-          searchParams={searchParams}
+          selectedGenres={selectedGenres}
+          selectedMoods={selectedMoods}
+          title={title}
         />
       </div>
     </div>

--- a/app/(main)/tracks/page.tsx
+++ b/app/(main)/tracks/page.tsx
@@ -1,11 +1,9 @@
 import { TrackList } from './TrackList';
-import { Input } from '@/components/ui/input';
-import { Search } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 import { Pagination } from './Pagination';
 import { getReleasedTracksServerAction } from '@/modules/track/domain/usecases/getReleasedTracksServerAction';
 import { TrackFilter } from './TrackFilter';
 import { useAppStore } from '@/store/useAppStore';
+import { TrackSearchBar } from './TrackSearchBar';
 
 export interface TracksSearchParams {
   page?: string;
@@ -57,16 +55,15 @@ export default async function TracksPage({
       <div className="w-full max-w-screen-xl py-16 space-y-8">
         <div className="text-5xl font-semibold">Search</div>
         <div className="flex items-center justify-between py-4">
-          <div className="relative flex items-center w-full">
-            <Search className="absolute left-2 w-4 h-4" />
-            <Input
-              className="h-10 max-w-xl pl-8 text-md"
-              placeholder="Search title, genres, moods"
-            />
-          </div>
+          <TrackSearchBar
+            searchParams={searchParams}
+            selectedGenres={selectedGenres}
+            selectedMoods={selectedMoods}
+          />
           <TrackFilter
             selectedGenres={selectedGenres}
             selectedMoods={selectedMoods}
+            searchParams={searchParams}
           />
         </div>
         <TrackList tracks={tracks} />

--- a/app/(main)/tracks/page.tsx
+++ b/app/(main)/tracks/page.tsx
@@ -1,16 +1,19 @@
-import { getAllTracksServerAction } from '@/modules/track/domain/usecases/getAllTracksServerAction';
 import { TrackList } from './TrackList';
 import { Input } from '@/components/ui/input';
 import { Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Pagination } from './Pagination';
+import { getReleasedTracksServerAction } from '@/modules/track/domain/usecases/getReleasedTracksServerAction';
 
 export default async function TracksPage({
   searchParams,
 }: {
   searchParams?: { [key: string]: string | string[] | undefined };
 }) {
-  const tracks = await getAllTracksServerAction();
+  const page = Number(searchParams?.page);
+  const { tracks, count } = await getReleasedTracksServerAction({
+    page: isNaN(page) ? 1 : page,
+  });
   return (
     <div className="flex flex-col items-center justify-between px-4">
       <div className="w-full max-w-screen-xl py-16 space-y-8">
@@ -29,9 +32,9 @@ export default async function TracksPage({
         </div>
         <TrackList tracks={tracks} />
         <Pagination
-          totalItems={140}
+          totalItems={count}
           take={10}
-          page={Number(searchParams?.page) ?? 1}
+          page={isNaN(page) ? 1 : page}
         />
       </div>
     </div>

--- a/app/(main)/tracks/page.tsx
+++ b/app/(main)/tracks/page.tsx
@@ -1,0 +1,39 @@
+import { getAllTracksServerAction } from '@/modules/track/domain/usecases/getAllTracksServerAction';
+import { TrackList } from './TrackList';
+import { Input } from '@/components/ui/input';
+import { Search } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Pagination } from './Pagination';
+
+export default async function TracksPage({
+  searchParams,
+}: {
+  searchParams?: { [key: string]: string | string[] | undefined };
+}) {
+  const tracks = await getAllTracksServerAction();
+  return (
+    <div className="flex flex-col items-center justify-between px-4">
+      <div className="w-full max-w-screen-xl py-16 space-y-8">
+        <div className="text-5xl font-semibold">Search</div>
+        <div className="flex items-center justify-between py-4">
+          <div className="relative flex items-center w-full">
+            <Search className="absolute left-2 w-4 h-4" />
+            <Input
+              className="h-10 max-w-xl pl-8 text-md"
+              placeholder="Search title, genres, moods"
+            />
+          </div>
+          <div>
+            <Button className="">Filter</Button>
+          </div>
+        </div>
+        <TrackList tracks={tracks} />
+        <Pagination
+          totalItems={140}
+          take={10}
+          page={Number(searchParams?.page) ?? 1}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,7 +40,6 @@ export default async function RootLayout({
   const likedTracks = await getLikedTracksServerAction(session?.user.id);
   const likedBundles = await getLikedBundlesServerAction(session?.user.id);
   const playlists = await getPlaylistsServerAction(session?.user.id);
-
   useUserStore.setState({
     likedTracks,
     likedBundles,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,9 @@ import { getLikedTracksServerAction } from '@/modules/track/domain/usecases/getL
 import { useUserStore } from '@/store/useUserStore';
 import { getLikedBundlesServerAction } from '@/modules/bundle/domain/usecases/getLikedBundlesServerAction';
 import { getPlaylistsServerAction } from '@/modules/playlist/domain/usecases/getPlaylistsServerAction';
+import { getAllGenresServerAction } from '@/modules/genre/domain/usecases/getAllGenresServerAction';
+import { getAllMoodsServerAction } from '@/modules/mood/domain/usecases/getAllMoodsServerAction';
+import { useAppStore } from '@/store/useAppStore';
 
 // Next의 런타임 참고
 // https://nextjs.org/docs/app/building-your-application/rendering/edge-and-nodejs-runtimes#edge-runtime
@@ -37,6 +40,8 @@ export default async function RootLayout({
   children: React.ReactNode;
 }) {
   const session = await getServerSession(authOptions);
+  const genres = await getAllGenresServerAction();
+  const moods = await getAllMoodsServerAction();
   const likedTracks = await getLikedTracksServerAction(session?.user.id);
   const likedBundles = await getLikedBundlesServerAction(session?.user.id);
   const playlists = await getPlaylistsServerAction(session?.user.id);
@@ -44,6 +49,10 @@ export default async function RootLayout({
     likedTracks,
     likedBundles,
     playlists,
+  });
+  useAppStore.setState({
+    genres,
+    moods,
   });
   return (
     <html lang="en" suppressHydrationWarning>
@@ -53,6 +62,8 @@ export default async function RootLayout({
             likedTracks={likedTracks}
             likedBundles={likedBundles}
             playlists={playlists}
+            genres={genres}
+            moods={moods}
           >
             <ThemeProvider
               attribute="class"

--- a/components/StoreProvider.tsx
+++ b/components/StoreProvider.tsx
@@ -11,12 +11,17 @@ import { Track } from '@/modules/track/domain/track';
 import { useUserStore } from '@/store/useUserStore';
 import { Bundle } from '@/modules/bundle/domain/bundle';
 import { UserPlaylist } from '@/modules/playlist/domain/playlist';
+import { Genre } from '@/modules/genre/domain/genre';
+import { Mood } from '@/modules/mood/domain/mood';
+import { useAppStore } from '@/store/useAppStore';
 
 interface Props {
   children: React.ReactNode;
   likedTracks: Track[];
   likedBundles: Bundle[];
   playlists: UserPlaylist[];
+  genres: Genre[];
+  moods: Mood[];
 }
 
 export function StoreProvider({
@@ -24,16 +29,24 @@ export function StoreProvider({
   likedTracks,
   likedBundles,
   playlists,
+  genres,
+  moods,
 }: Props) {
   const initPlayerStore = usePlayerStore((state) => state.initPlayerStore);
   const [setLikedTracks, setLikedBundles, setPlaylists] = useUserStore(
     (state) => [state.setLikedTracks, state.setLikedBundles, state.setPlaylists]
   );
+  const [setGenres, setMoods] = useAppStore((state) => [
+    state.setGenres,
+    state.setMoods,
+  ]);
 
   useEffect(() => {
     setLikedTracks(likedTracks);
     setLikedBundles(likedBundles);
     setPlaylists(playlists);
+    setGenres(genres);
+    setMoods(moods);
   }, [
     likedTracks,
     setLikedTracks,
@@ -41,6 +54,10 @@ export function StoreProvider({
     setLikedBundles,
     playlists,
     setPlaylists,
+    setGenres,
+    genres,
+    setMoods,
+    moods,
   ]);
 
   useEffect(() => {

--- a/components/player/Player.tsx
+++ b/components/player/Player.tsx
@@ -30,6 +30,7 @@ export const Player = () => {
     return null;
   }
 
+  // 플레이어를 닫으면 오디오와 관련된 자원들 모두 클린업
   return isPlayerOpen ? (
     <div
       className={cn(

--- a/components/player/useAudioPlayer.ts
+++ b/components/player/useAudioPlayer.ts
@@ -42,7 +42,10 @@ export const useAudioPlayer = ({
   // 트랙/번들/플레이리스트 변경 시 audioElement 등록 && 기존 상태 유지(volume, isPlaying)
   useEffect(() => {
     if (!trackSrc) {
-      if (audioRef.current) audioRef.current.src = '';
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current.src = '';
+      }
       setAudioElement(null);
     }
     if (!audioRef.current || !trackSrc) {

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/lib/queryString.ts
+++ b/lib/queryString.ts
@@ -1,0 +1,36 @@
+export const parseStringToArrayNumber = (
+  param?: string | string[]
+): number[] => {
+  if (!param) return [];
+  if (Array.isArray(param)) {
+    return param.map(Number).filter((item) => !isNaN(item));
+  }
+  try {
+    const parsed = JSON.parse(param);
+    return Array.isArray(parsed)
+      ? parsed.map(Number).filter((item) => !isNaN(item))
+      : [];
+  } catch (e) {
+    return [];
+  }
+};
+
+export const createTracksQueryString = ({
+  title,
+  genreIds,
+  moodIds,
+  page = 1,
+}: {
+  title?: string;
+  genreIds?: number[];
+  moodIds?: number[];
+  page?: number;
+}) => {
+  const query = [];
+  if (genreIds && genreIds.length) query.push(`genres=[${genreIds.join(',')}]`);
+  if (moodIds && moodIds.length) query.push(`moods=[${moodIds.join(',')}]`);
+  if (title) query.push(`title=${encodeURIComponent(title)}`);
+  query.push(`page=${page}`);
+
+  return query.join('&');
+};

--- a/modules/config/cacheHelper.ts
+++ b/modules/config/cacheHelper.ts
@@ -12,15 +12,15 @@ export const cacheKeys = {
   getLikedTracksByUser: (userId: string) => `likedTracksByUser_${userId}`,
 
   getReleasedTracksWithQuery: (query: RepositoryGetTracksQuery) =>
-    `releasedTracksWithQuery_genre=${query.genre || 'all'}&mood=${
-      query.mood || 'all'
+    `releasedTracksWithQuery_genre=[${query.genres || ''}]&mood=${
+      query.moods || 'all'
     }&page=${query.page || 1}&take=${query.take || 15}&title=${
       query.title || ''
     }`,
 
   getCountTracksWithQuery: (query: RepositoryGetTracksQuery) =>
-    `getCountTracksWithQuery_genre=${query.genre || 'all'}&mood=${
-      query.mood || 'all'
+    `getCountTracksWithQuery_genre=[${query.genres || ''}]&mood=${
+      query.moods || 'all'
     }&title=${query.title || ''}`,
 
   ADMIN_ALL_BUNDLES: 'adminAllTracks', // 어드민이 사용하는 전체 번들

--- a/modules/config/cacheHelper.ts
+++ b/modules/config/cacheHelper.ts
@@ -1,3 +1,5 @@
+import { RepositoryGetTracksQuery } from '../track/domain/validations/GetTrackTypes';
+
 export const cacheKeys = {
   ALL_MOODS: 'allMoods',
   ALL_GENRES: 'allGenres',
@@ -8,7 +10,18 @@ export const cacheKeys = {
 
   getTrack: (trackId: number) => `track_${trackId}`,
   getLikedTracksByUser: (userId: string) => `likedTracksByUser_${userId}`,
-  getReleasedTracksByGenre: (genre: string) => `releasedTracksByGenre_${genre}`,
+
+  getReleasedTracksWithQuery: (query: RepositoryGetTracksQuery) =>
+    `releasedTracksWithQuery_genre=${query.genre || 'all'}&mood=${
+      query.mood || 'all'
+    }&page=${query.page || 1}&take=${query.take || 15}&title=${
+      query.title || ''
+    }`,
+
+  getCountTracksWithQuery: (query: RepositoryGetTracksQuery) =>
+    `getCountTracksWithQuery_genre=${query.genre || 'all'}&mood=${
+      query.mood || 'all'
+    }&title=${query.title || ''}`,
 
   ADMIN_ALL_BUNDLES: 'adminAllTracks', // 어드민이 사용하는 전체 번들
   RELEASED_BUNDLES: 'releasedTrack', // relaesed된 전체 번들

--- a/modules/config/cacheHelper.ts
+++ b/modules/config/cacheHelper.ts
@@ -12,16 +12,16 @@ export const cacheKeys = {
   getLikedTracksByUser: (userId: string) => `likedTracksByUser_${userId}`,
 
   getReleasedTracksWithQuery: (query: RepositoryGetTracksQuery) =>
-    `releasedTracksWithQuery_genre=[${query.genres || ''}]&mood=${
-      query.moods || 'all'
-    }&page=${query.page || 1}&take=${query.take || 15}&title=${
+    `releasedTracksWithQuery_genre=[${query.genres || ''}]&mood=[${
+      query.moods || ''
+    }]&page=${query.page || 1}&take=${query.take || 15}&title=${
       query.title || ''
     }`,
 
   getCountTracksWithQuery: (query: RepositoryGetTracksQuery) =>
-    `getCountTracksWithQuery_genre=[${query.genres || ''}]&mood=${
-      query.moods || 'all'
-    }&title=${query.title || ''}`,
+    `getCountTracksWithQuery_genre=[${query.genres || ''}]&mood=[${
+      query.moods || ''
+    }]&title=${query.title || ''}`,
 
   ADMIN_ALL_BUNDLES: 'adminAllTracks', // 어드민이 사용하는 전체 번들
   RELEASED_BUNDLES: 'releasedTrack', // relaesed된 전체 번들

--- a/modules/stem/application/CreateStemForm.tsx
+++ b/modules/stem/application/CreateStemForm.tsx
@@ -9,7 +9,6 @@ import {
   Select,
   SelectContent,
   SelectItem,
-  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';

--- a/modules/stem/domain/usecases/createStemServerAction.ts
+++ b/modules/stem/domain/usecases/createStemServerAction.ts
@@ -32,10 +32,7 @@ export const createStemServerAction = adminGuard(
       revalidateTag(cacheKeys.getTrack(trackId));
 
       if (track.status === TrackStatus.PUBLISH) {
-        revalidateTag(cacheKeys.getReleasedTracksByGenre('all'));
-        track.genres.forEach((genre) => {
-          revalidateTag(cacheKeys.getReleasedTracksByGenre(genre.slug));
-        });
+        revalidateTag(cacheKeys.RELEASED_TRACKS);
       }
 
       return { success: true, stem };

--- a/modules/stem/domain/usecases/deleteStemServerAction.ts
+++ b/modules/stem/domain/usecases/deleteStemServerAction.ts
@@ -24,10 +24,7 @@ export const deleteStemServerAction = adminGuard(
         revalidateTag(cacheKeys.getTrack(track.id));
 
         if (track.status === TrackStatus.PUBLISH) {
-          revalidateTag(cacheKeys.getReleasedTracksByGenre('all'));
-          track.genres.forEach((genre) => {
-            revalidateTag(cacheKeys.getReleasedTracksByGenre(genre.slug));
-          });
+          revalidateTag(cacheKeys.RELEASED_TRACKS);
         }
       }
 

--- a/modules/track/domain/track.repository.ts
+++ b/modules/track/domain/track.repository.ts
@@ -7,6 +7,8 @@ export interface TrackRepository {
   findById: (id: number) => Promise<DomainTrack | null>;
   findAll: () => Promise<DomainTrack[]>;
   findAllWithQuery: (query: RepositoryGetTracksQuery) => Promise<DomainTrack[]>;
+  countTracksWithQuery: (query: RepositoryGetTracksQuery) => Promise<number>;
+
   create: (data: RepositoryCreateTrackInput) => Promise<DomainTrack>;
   edit: (id: number, data: RepositoryEditTrackInput) => Promise<DomainTrack>;
   delete: (id: number) => Promise<DomainTrack>;

--- a/modules/track/domain/usecases/editTrackServerAction.ts
+++ b/modules/track/domain/usecases/editTrackServerAction.ts
@@ -73,11 +73,11 @@ export const editTrackServerAction = adminGuard(
         exist.status === TrackStatus.PUBLISH ||
         result.status === TrackStatus.PUBLISH
       ) {
-        revalidateTag(cacheKeys.getReleasedTracksByGenre('all'));
+        revalidateTag(cacheKeys.getReleasedTracksWithQuery({}));
         const _genres = new Set([...exist.genres, ...result.genres]);
 
         _genres.forEach((t) =>
-          revalidateTag(cacheKeys.getReleasedTracksByGenre(t.slug))
+          revalidateTag(cacheKeys.getReleasedTracksWithQuery({ genre: t.slug }))
         );
       }
 

--- a/modules/track/domain/usecases/editTrackServerAction.ts
+++ b/modules/track/domain/usecases/editTrackServerAction.ts
@@ -73,12 +73,7 @@ export const editTrackServerAction = adminGuard(
         exist.status === TrackStatus.PUBLISH ||
         result.status === TrackStatus.PUBLISH
       ) {
-        revalidateTag(cacheKeys.getReleasedTracksWithQuery({}));
-        const _genres = new Set([...exist.genres, ...result.genres]);
-
-        _genres.forEach((t) =>
-          revalidateTag(cacheKeys.getReleasedTracksWithQuery({ genre: t.slug }))
-        );
+        revalidateTag(cacheKeys.RELEASED_TRACKS);
       }
 
       return { success: true, track: result };

--- a/modules/track/domain/usecases/getReleasedTracksServerAction.ts
+++ b/modules/track/domain/usecases/getReleasedTracksServerAction.ts
@@ -15,7 +15,7 @@ export const getReleasedTracksServerAction = async (
     const tracks = await unstable_cache(
       async () => {
         const data = await repo.findAllWithQuery({
-          genre: query.genre,
+          genres: query.genres,
           page: query.page,
           take: query.take,
         });

--- a/modules/track/domain/usecases/getReleasedTracksServerAction.ts
+++ b/modules/track/domain/usecases/getReleasedTracksServerAction.ts
@@ -12,10 +12,15 @@ export const getReleasedTracksServerAction = async (
 ) => {
   const repo = subTrackRepository || repository.track;
   try {
+    query.genres?.sort((a, b) => a - b);
+    query.moods?.sort((a, b) => a - b);
+
     const tracks = await unstable_cache(
       async () => {
         const data = await repo.findAllWithQuery({
+          title: query.title,
           genres: query.genres,
+          moods: query.moods,
           page: query.page,
           take: query.take,
         });

--- a/modules/track/domain/validations/GetTrackTypes.ts
+++ b/modules/track/domain/validations/GetTrackTypes.ts
@@ -1,6 +1,7 @@
 export type RepositoryGetTracksQuery = {
   page?: number;
-  count?: number;
+  take?: number;
   genre?: string;
   mood?: string;
+  title?: string;
 };

--- a/modules/track/domain/validations/GetTrackTypes.ts
+++ b/modules/track/domain/validations/GetTrackTypes.ts
@@ -1,7 +1,7 @@
 export type RepositoryGetTracksQuery = {
   page?: number;
   take?: number;
-  genre?: string;
-  mood?: string;
+  genres?: number[];
+  moods?: number[];
   title?: string;
 };

--- a/modules/track/infrastructure/track.prisma.repository.ts
+++ b/modules/track/infrastructure/track.prisma.repository.ts
@@ -37,26 +37,32 @@ export class TrackPrismaRepository implements TrackRepository {
   async countTracksWithQuery(query: RepositoryGetTracksQuery) {
     const { genres, moods, title } = query;
 
-    let whereCondition: any = {};
+    let whereCondition: any = {
+      status: 'PUBLISH',
+    };
 
     if (genres && 0 < genres.length) {
-      whereCondition.genres = {
-        some: {
-          id: {
-            in: genres,
+      whereCondition.AND = genres.map((id) => ({
+        genres: {
+          some: {
+            id: id,
           },
         },
-      };
+      }));
     }
 
     if (moods && 0 < moods.length) {
-      whereCondition.moods = {
-        some: {
-          id: {
-            in: moods,
+      const moodConditions = moods.map((id) => ({
+        moods: {
+          some: {
+            id: id,
           },
         },
-      };
+      }));
+
+      whereCondition.AND = whereCondition.AND
+        ? [...whereCondition.AND, ...moodConditions]
+        : moodConditions;
     }
 
     if (title) {
@@ -64,7 +70,7 @@ export class TrackPrismaRepository implements TrackRepository {
     }
 
     const count = await prisma.track.count({
-      where: { ...whereCondition, status: 'PUBLISH' },
+      where: { ...whereCondition },
     });
 
     return count;
@@ -74,26 +80,32 @@ export class TrackPrismaRepository implements TrackRepository {
     const { page = 1, take = 10, genres, moods, title } = query;
     const offset = (page - 1) * 10;
 
-    let whereCondition: any = {};
+    let whereCondition: any = {
+      status: 'PUBLISH',
+    };
 
     if (genres && 0 < genres.length) {
-      whereCondition.genres = {
-        some: {
-          id: {
-            in: genres,
+      whereCondition.AND = genres.map((id) => ({
+        genres: {
+          some: {
+            id: id,
           },
         },
-      };
+      }));
     }
 
     if (moods && 0 < moods.length) {
-      whereCondition.moods = {
-        some: {
-          id: {
-            in: moods,
+      const moodConditions = moods.map((id) => ({
+        moods: {
+          some: {
+            id: id,
           },
         },
-      };
+      }));
+
+      whereCondition.AND = whereCondition.AND
+        ? [...whereCondition.AND, ...moodConditions]
+        : moodConditions;
     }
 
     if (title) {
@@ -103,7 +115,6 @@ export class TrackPrismaRepository implements TrackRepository {
     const tracks = await prisma.track.findMany({
       where: {
         ...whereCondition,
-        status: 'PUBLISH',
       },
       orderBy: {
         id: 'desc',

--- a/modules/track/infrastructure/track.prisma.repository.ts
+++ b/modules/track/infrastructure/track.prisma.repository.ts
@@ -35,16 +35,28 @@ export class TrackPrismaRepository implements TrackRepository {
   }
 
   async countTracksWithQuery(query: RepositoryGetTracksQuery) {
-    const { genre, mood, title } = query;
+    const { genres, moods, title } = query;
 
     let whereCondition: any = {};
 
-    if (genre) {
-      whereCondition.genres = { some: { slug: genre } };
+    if (genres && 0 < genres.length) {
+      whereCondition.genres = {
+        some: {
+          id: {
+            in: genres,
+          },
+        },
+      };
     }
 
-    if (mood) {
-      whereCondition.moods = { some: { tag: mood } };
+    if (moods && 0 < moods.length) {
+      whereCondition.moods = {
+        some: {
+          id: {
+            in: moods,
+          },
+        },
+      };
     }
 
     if (title) {
@@ -59,23 +71,27 @@ export class TrackPrismaRepository implements TrackRepository {
   }
 
   async findAllWithQuery(query: RepositoryGetTracksQuery) {
-    const { page = 1, take = 10, genre, mood, title } = query;
+    const { page = 1, take = 10, genres, moods, title } = query;
     const offset = (page - 1) * 10;
 
     let whereCondition: any = {};
 
-    if (genre) {
+    if (genres && 0 < genres.length) {
       whereCondition.genres = {
         some: {
-          slug: genre,
+          id: {
+            in: genres,
+          },
         },
       };
     }
 
-    if (mood) {
+    if (moods && 0 < moods.length) {
       whereCondition.moods = {
         some: {
-          tag: mood,
+          id: {
+            in: moods,
+          },
         },
       };
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.5",
+        "@radix-ui/react-tooltip": "^1.0.7",
         "@tanstack/react-table": "^8.10.3",
         "@types/bcrypt": "^5.0.0",
         "@types/node": "20.5.9",
@@ -2133,6 +2134,40 @@
         "@radix-ui/react-use-callback-ref": "1.0.1",
         "@radix-ui/react-use-controllable-state": "1.0.1",
         "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.0.7.tgz",
+      "integrity": "sha512-lPh5iKNFVQ/jav/j6ZrWq3blfDJ0OH9R6FlNUHPMqdLuQ9vwDgFsRxvl8b7Asuy5c8xmoojHUxKHQSOAvMHxyw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
         "@radix-ui/react-visually-hidden": "1.0.3"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",
+    "@radix-ui/react-tooltip": "^1.0.7",
     "@tanstack/react-table": "^8.10.3",
     "@types/bcrypt": "^5.0.0",
     "@types/node": "20.5.9",

--- a/store/useAppStore.ts
+++ b/store/useAppStore.ts
@@ -1,0 +1,23 @@
+import { Genre } from '@/modules/genre/domain/genre';
+import { Mood } from '@/modules/mood/domain/mood';
+import { create } from 'zustand';
+
+export interface AppStoreState {
+  genres: Genre[];
+  moods: Mood[];
+}
+interface AppStoreActions {
+  setGenres: (genres: Genre[]) => void;
+  setMoods: (moods: Mood[]) => void;
+}
+
+export const useAppStore = create<AppStoreState & AppStoreActions>((set) => ({
+  genres: [],
+  moods: [],
+  setGenres: (genres) => {
+    set({ genres: genres });
+  },
+  setMoods: (moods) => {
+    set({ moods: moods });
+  },
+}));

--- a/store/useUIStatusStorage.ts
+++ b/store/useUIStatusStorage.ts
@@ -27,6 +27,6 @@ export const useUIStatusStore = create<
   closePlayer: () => {
     useUIStatusStore.getState().setIsPlyerOpen(false);
     usePlayerStore.getState().setPlaylist('', '', []);
-    usePlayerStore.getState().setTrack(null);
+    usePlayerStore.getState().setTrack(null, null);
   },
 }));


### PR DESCRIPTION
트랙 페이지 추가

1. 트랙 검색 기능
2. 검색 쿼리 추가 (title, genres, moods, page)
3. 트랙 조회 usecases 변경에 따른 메인 페이지 대응
4. 트랙 조회 캐시 헬퍼 수정

query string을 사용하여 route 변경에 따른 조회 serverActions을 실행하고, 
각 releasedTracksWithQuery_genre=[]&mood=[]&page=&take=&title= 로 캐싱